### PR TITLE
Toolchain for emscripten

### DIFF
--- a/conditions/amu/attack_counter.c
+++ b/conditions/amu/attack_counter.c
@@ -11,6 +11,7 @@
 #include "debugging/trace.h"
 
 #include "debugging/assert.h"
+#include "solving/post_move_iteration.h"
 
 boolean amu_attacked_exactly_once[maxply+1];
 

--- a/debugging/assert.c
+++ b/debugging/assert.c
@@ -9,6 +9,8 @@ void assert_impl(char const *assertion, const char *file, int line)
   move_generator_write_history();
   move_numbers_write_history();
 
+#ifndef EMSCRIPTEN
+
 #if defined(_WIN32) || defined(_WIN64)
   /* why can't these guys do anything in a standard conforming way??? */
   _assert
@@ -16,4 +18,6 @@ void assert_impl(char const *assertion, const char *file, int line)
   __assert
 #endif
   (assertion,file,line);
+
+#endif
 }

--- a/makefile.defaults
+++ b/makefile.defaults
@@ -187,6 +187,11 @@ COMPRESS = echo compress
 #COMPRESS = compress
 
 
+# How shell should execute built files
+# ====================================
+EXECUTE=
+
+
 # include toolchain-specific settings and overriders
 
 TOOLCHAIN=gcc

--- a/makefile.local
+++ b/makefile.local
@@ -66,7 +66,7 @@ gengmarr$(EXE_SUFFIX):	gengmarr$(OBJ_SUFFIX) position/position-host$(OBJ_SUFFIX)
 
 
 pygmarr.c: ./gengmarr$(EXE_SUFFIX)
-	./gengmarr$(EXE_SUFFIX) > $@
+	$(EXECUTE) ./gengmarr$(EXE_SUFFIX) > $@
 
 
 # ===========================================================

--- a/toolchains/emcc/make.incl
+++ b/toolchains/emcc/make.incl
@@ -5,7 +5,8 @@
 
 # Requirements:
 #
-# Emscripten SDK and Java
+# Java and Emscripten SDK (always go for the bleeding edge, 
+# forget 'apt-get install emscripten') 
 #
 
 
@@ -13,10 +14,13 @@ include toolchains/gcc/make.incl
 CCHOST=emcc
 LDHOST=emcc
 CCTARGET=emcc
-LDTARGET=emcc
+LDTARGET=emcc -s EXPORTED_FUNCTIONS="['_main']" --memory-init-file 0 -s TOTAL_MEMORY=33554432 -s ABORTING_MALLOC=0
 EXE_SUFFIX=.js
-STRIPTARGET=@echo "already stripped"
-CCOPTIM=
-LDOPTIM=
-EXECUTE=nodejs
+ARCHIVER=emar rv
+ARCHIVE_INDEXER=emranlib
+STRIPTARGET=@echo "no need to strip"
+CCOPTIM=-O3
+LDOPTIM=-O3
+EXECUTE=node
 OSTYPE=asm.js
+PLATFORM=unix

--- a/toolchains/emcc/make.incl
+++ b/toolchains/emcc/make.incl
@@ -1,0 +1,22 @@
+# -*- Makefile -*-
+#
+
+# Include file for makefile.unx for compiling on Linux using emcc
+
+# Requirements:
+#
+# Emscripten SDK and Java
+#
+
+
+include toolchains/gcc/make.incl
+CCHOST=emcc
+LDHOST=emcc
+CCTARGET=emcc
+LDTARGET=emcc
+EXE_SUFFIX=.js
+STRIPTARGET=@echo "already stripped"
+CCOPTIM=
+LDOPTIM=
+EXECUTE=nodejs
+OSTYPE=asm.js

--- a/toolchains/emcc/makefile.local
+++ b/toolchains/emcc/makefile.local
@@ -1,0 +1,6 @@
+# -*- Makefile -*-
+#
+
+include makefile.rules
+
+DISTRIBUTEDFILES = 	makefile.local make.incl


### PR DESCRIPTION
This introduces the support for emscripten toolchain in popeye.
Compiled into asm.js, popeye can be embedded into web pages and be executed on mobile platforms.
Please see this forum post for details of the example implementation:
http://www.matplus.net/start.php?app=forum&act=posts&fid=it&tid=1923