### PR TITLE
Fixing issue #260.

### DIFF
--- a/input/plaintext/condition.c
+++ b/input/plaintext/condition.c
@@ -77,7 +77,7 @@ static char *ParsePieceWalkAndSquareLastCapture(char *tok)
   }
   else
   {
-    output_plaintext_input_error_message(WrongPieceName,0);
+    output_plaintext_input_error_message(WrongPieceName);
     tok = ReadNextTokStr();
   }
 
@@ -241,7 +241,7 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
       break;
     else if (index>CirceVariantCount)
     {
-      output_plaintext_input_error_message(CondNotUniq,0);
+      output_plaintext_input_error_message(CondNotUniq);
       break;
     }
     else
@@ -260,17 +260,17 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
 
         case CirceVariantMirror:
           if (!circe_override_relevant_side_overrider(variant,circe_relevant_side_overrider_mirror))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantDiametral:
           if (!circe_override_rebirth_square_adapter(variant,circe_rebirth_square_adapter_diametral))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantVerticalMirror:
           if (!circe_override_rebirth_square_adapter(variant,circe_rebirth_square_adapter_verticalmirror))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantAssassin:
@@ -279,17 +279,17 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
 
         case CirceVariantClone:
           if (!circe_override_reborn_walk_adapter(variant,circe_reborn_walk_adapter_clone))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantEinstein:
           if (!circe_override_reborn_walk_adapter(variant,circe_reborn_walk_adapter_einstein))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantReverseEinstein:
           if (!circe_override_reborn_walk_adapter(variant,circe_reborn_walk_adapter_reversaleinstein))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantChameleon:
@@ -301,7 +301,7 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
             variant->is_chameleon_sequence_explicit = variant->explicit_chameleon_squence_set_in_twin==twin_id;
           }
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantTurncoats:
@@ -321,7 +321,7 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
           if (circe_override_determine_rebirth_square(variant,circe_determine_rebirth_square_equipollents))
             variant->is_promotion_possible = true;
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantParrain:
@@ -331,7 +331,7 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
             variant->is_promotion_possible = true;
           }
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantContraParrain:
@@ -342,7 +342,7 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
             variant->is_promotion_possible = true;
           }
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantCage:
@@ -352,59 +352,59 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
             variant->rebirth_reason = move_effect_reason_rebirth_choice;
           }
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantRank:
           if (!circe_override_determine_rebirth_square(variant,circe_determine_rebirth_square_rank)
               || !circe_override_rebirth_square_adapter(variant,circe_rebirth_square_adapter_rank)
               || !circe_override_relevant_side_overrider(variant,circe_relevant_side_overrider_rank))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantFile:
           if (!circe_override_determine_rebirth_square(variant,circe_determine_rebirth_square_file))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantSymmetry:
           if (circe_override_determine_rebirth_square(variant,circe_determine_rebirth_square_symmetry))
             variant->is_promotion_possible = true;
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantVerticalSymmetry:
           if (circe_override_determine_rebirth_square(variant,circe_determine_rebirth_square_vertical_symmetry))
             variant->is_promotion_possible = true;
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantHorizontalSymmetry:
           if (circe_override_determine_rebirth_square(variant,circe_determine_rebirth_square_horizontal_symmetry))
             variant->is_promotion_possible = false;
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantDiagramm:
           if (!circe_override_determine_rebirth_square(variant,circe_determine_rebirth_square_diagram))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantPWC:
           if (circe_override_determine_rebirth_square(variant,circe_determine_rebirth_square_pwc))
             variant->is_promotion_possible = true;
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantAntipodes:
           if (circe_override_determine_rebirth_square(variant,circe_determine_rebirth_square_antipodes))
             variant->is_promotion_possible = true;
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantSuper:
@@ -414,7 +414,7 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
             variant->rebirth_reason = move_effect_reason_rebirth_choice;
           }
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantTakeAndMake:
@@ -424,7 +424,7 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
             variant->rebirth_reason = move_effect_reason_rebirth_choice;
           }
           else
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantApril:
@@ -432,7 +432,7 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
           unsigned int nr_walks_read;
           tok = ReadWalks(tok,&variant->is_walk_affected,&nr_walks_read);
           if (nr_walks_read==0)
-            output_plaintext_input_error_message(WrongPieceName,0);
+            output_plaintext_input_error_message(WrongPieceName);
           else
           {
             variant->is_restricted_to_walks = true;
@@ -444,7 +444,7 @@ static char *ParseCirceVariants(char *tok, circe_variant_type *variant)
 
         case CirceVariantFrischauf:
           if (!circe_override_rebirth_square_adapter(variant,circe_rebirth_square_adapter_frischauf))
-            output_plaintext_input_error_message(NonsenseCombination,0);
+            output_plaintext_input_error_message(NonsenseCombination);
           break;
 
         case CirceVariantCalvet:
@@ -508,7 +508,7 @@ static char *ParseSquaresWithFlag(char *tok, SquareFlags flag)
 
   tok = ParseSquareList(squares_tok,&HandleSquaresWithFlag,&flag);
   if (tok==squares_tok)
-    output_plaintext_input_error_message(MissngSquareList,0);
+    output_plaintext_input_error_message(MissngSquareList);
   else if (*tok!=0)
     output_plaintext_error_message(WrongSquareList);
 
@@ -535,7 +535,7 @@ static char *ParseRoyalSquare(char *tok, Side side)
 
   tok = ParseSquare(tok,&sq);
   if (sq==initsquare || tok[0]!=0)
-    output_plaintext_input_error_message(WrongSquareList, 0);
+    output_plaintext_input_error_message(WrongSquareList);
   else
     royal_square[side] = sq;
 
@@ -554,7 +554,7 @@ static char *ParseKobulSides(char *tok, boolean (*variant)[nr_sides])
     KobulVariantType const type = GetUniqIndex(KobulVariantCount,KobulVariantTypeTab,tok);
 
     if (type>KobulVariantCount)
-      output_plaintext_input_error_message(CondNotUniq,0);
+      output_plaintext_input_error_message(CondNotUniq);
     else if (type==KobulWhiteOnly)
       (*variant)[Black] = false;
     else if (type==KobulBlackOnly)
@@ -610,7 +610,7 @@ static char *ParseSentinellesVariants(char *tok)
     SentinellesVariantType const type = GetUniqIndex(SentinellesVariantCount,SentinellesVariantTypeTab,tok);
 
     if (type>SentinellesVariantCount)
-      output_plaintext_input_error_message(CondNotUniq,0);
+      output_plaintext_input_error_message(CondNotUniq);
     else if (type==SentinellesVariantPionAdverse)
     {
       sentinelles_pawn_mode = sentinelles_pawn_adverse;
@@ -661,7 +661,7 @@ static char *ParseBretonVariants(char *tok)
     BretonVariantType const type = GetUniqIndex(BretonVariantCount,BretonVariantTypeTab,tok);
 
     if (type>BretonVariantCount)
-      output_plaintext_input_error_message(CondNotUniq,0);
+      output_plaintext_input_error_message(CondNotUniq);
     else if (type==BretonAdverse)
     {
       breton_mode = breton_adverse;
@@ -818,7 +818,7 @@ static char *ParseGridVariant(char *tok)
             tok = ReadNextTokStr();
           }
           else
-            output_plaintext_input_error_message(CondNotUniq, 0);
+            output_plaintext_input_error_message(CondNotUniq);
 
           break;
         }
@@ -889,7 +889,7 @@ static char *ParseGridVariant(char *tok)
           break;
         }
         default:
-          output_plaintext_input_error_message(CondNotUniq,0);
+          output_plaintext_input_error_message(CondNotUniq);
           break;
       }
     }
@@ -912,7 +912,7 @@ static char *ParseKoekoVariant(char *tok)
     /* nothing */
   }
   else if (type>1)
-    output_plaintext_input_error_message(CondNotUniq,0);
+    output_plaintext_input_error_message(CondNotUniq);
   else
   {
     piece_walk_type tmp_piece;
@@ -950,7 +950,7 @@ static char *ParseKoekoVariant(char *tok)
         *nocontactfunc_parsed= noantelopecontact;
         break;
       default:
-        output_plaintext_input_error_message(WrongPieceName,0);
+        output_plaintext_input_error_message(WrongPieceName);
         break;
     }
   }
@@ -971,7 +971,7 @@ static char *ParseLetteredType(char *tok,
    /* nothing */
   }
   else if (type_read>ConditionLetteredVariantTypeCount)
-    output_plaintext_input_error_message(CondNotUniq,0);
+    output_plaintext_input_error_message(CondNotUniq);
   else
   {
     ConditionLetteredVariantType type;
@@ -1000,7 +1000,7 @@ static char *ParseNumberedType(char *tok,
     /* nothing */
   }
   else if (type_read>ConditionNumberedVariantTypeCount)
-    output_plaintext_input_error_message(CondNotUniq,0);
+    output_plaintext_input_error_message(CondNotUniq);
   else
   {
     ConditionNumberedVariantType type;
@@ -1025,7 +1025,7 @@ static char *ParseAnticirceVariant(char *tok, anticirce_type_type *variant)
     return tok;
   else if (type>anticirce_type_count)
   {
-    output_plaintext_input_error_message(CondNotUniq,0);
+    output_plaintext_input_error_message(CondNotUniq);
     return tok;
   }
   else if (type==anticirce_type_cheylan || type==anticirce_type_calvet)
@@ -1110,7 +1110,7 @@ char *ParseCond(char *tok)
       ExtraCond const extra = GetUniqIndex(ExtraCondCount,ExtraCondTab,tok);
       if (extra>ExtraCondCount)
       {
-        output_plaintext_input_error_message(CondNotUniq,0);
+        output_plaintext_input_error_message(CondNotUniq);
         tok = ReadNextTokStr();
         break;
       }
@@ -1141,7 +1141,7 @@ char *ParseCond(char *tok)
     }
     else if (cond>CondCount)
     {
-      output_plaintext_input_error_message(CondNotUniq,0);
+      output_plaintext_input_error_message(CondNotUniq);
       tok = ReadNextTokStr();
     }
     else
@@ -1173,7 +1173,7 @@ char *ParseCond(char *tok)
                                 &HandleImitatorPosition,
                                 &being_solved.number_of_imitators);
           if (tok==squares_tok)
-            output_plaintext_input_error_message(MissngSquareList,0);
+            output_plaintext_input_error_message(MissngSquareList);
           else if (*tok!=0)
             output_plaintext_error_message(WrongSquareList);
 
@@ -1203,7 +1203,7 @@ char *ParseCond(char *tok)
 
           tok = ParseSquareList(squares_tok,&HandleHole,0);
           if (tok==squares_tok)
-            output_plaintext_input_error_message(MissngSquareList,0);
+            output_plaintext_input_error_message(MissngSquareList);
           else if (*tok!=0)
             output_plaintext_error_message(WrongSquareList);
 
@@ -1492,7 +1492,7 @@ char *ParseCond(char *tok)
           if (nr_walks_read==0)
           {
             CondFlag[april] = false;
-            output_plaintext_input_error_message(WrongPieceName,0);
+            output_plaintext_input_error_message(WrongPieceName);
           }
           else
           {
@@ -1735,7 +1735,7 @@ char *ParseCond(char *tok)
           if (nr_walks_read==0)
           {
             CondFlag[promotiononly] = false;
-            output_plaintext_input_error_message(WrongPieceName,0);
+            output_plaintext_input_error_message(WrongPieceName);
           }
           break;
         }
@@ -1838,7 +1838,7 @@ char *ParseCond(char *tok)
   while (true);
 
   if (CondCnt==0)
-    output_plaintext_input_error_message(UnrecCondition,0);
+    output_plaintext_input_error_message(UnrecCondition);
 
   if (CondFlag[black_oscillatingKs] && OscillatingKings[Black]==ConditionTypeC
       && CondFlag[white_oscillatingKs] && OscillatingKings[White]==ConditionTypeC)

--- a/input/plaintext/goal.c
+++ b/input/plaintext/goal.c
@@ -143,7 +143,7 @@ char *ParseGoal(char *tok, slice_index start, slice_index proxy)
 
         if (goal.target==initsquare)
         {
-          output_plaintext_input_error_message(MissngSquareList, 0);
+          output_plaintext_input_error_message(MissngSquareList);
           tok = 0;
         }
         else
@@ -283,7 +283,7 @@ char *ParseGoal(char *tok, slice_index start, slice_index proxy)
 
           if (goal.target==initsquare)
           {
-            output_plaintext_input_error_message(MissngSquareList, 0);
+            output_plaintext_input_error_message(MissngSquareList);
             tok = 0;
           }
           else

--- a/input/plaintext/option.c
+++ b/input/plaintext/option.c
@@ -132,7 +132,7 @@ char *ParseOpt(slice_index start)
 
     if (indexx>OptCount)
     {
-      output_plaintext_input_error_message(OptNotUniq,0);
+      output_plaintext_input_error_message(OptNotUniq);
       continue;
     }
     OptFlag[indexx]= true;
@@ -159,7 +159,7 @@ char *ParseOpt(slice_index start)
         if (*end!=0 || value==0 || value>UINT_MAX)
         {
           OptFlag[maxtime]= false;
-          output_plaintext_input_error_message(WrongInt, 0);
+          output_plaintext_input_error_message(WrongInt);
           indexx = OptCount;
         }
         else
@@ -174,7 +174,7 @@ char *ParseOpt(slice_index start)
         tok = ParseSquareList(squares_tok,&HandleEpSquare,0);
         if (tok==squares_tok)
         {
-          output_plaintext_input_error_message(MissngSquareList,0);
+          output_plaintext_input_error_message(MissngSquareList);
           indexx = OptCount+1;
         }
         else if (*tok!=0)
@@ -192,7 +192,7 @@ char *ParseOpt(slice_index start)
             maxsolutions_instrument_problem(start,(unsigned int)value);
           else
           {
-            output_plaintext_input_error_message(WrongInt,0);
+            output_plaintext_input_error_message(WrongInt);
             indexx = OptCount;
           }
         }
@@ -221,7 +221,7 @@ char *ParseOpt(slice_index start)
         if (!read_restart_number(tok))
         {
           OptFlag[restart] = false;
-          output_plaintext_input_error_message(WrongInt,0);
+          output_plaintext_input_error_message(WrongInt);
           indexx = OptCount;
         }
         OptFlag[movenbr]= true;
@@ -237,7 +237,7 @@ char *ParseOpt(slice_index start)
         else
         {
           OptFlag[solmenaces] = false;
-          output_plaintext_input_error_message(WrongInt,0);
+          output_plaintext_input_error_message(WrongInt);
           indexx = OptCount;
         }
         break;
@@ -247,7 +247,7 @@ char *ParseOpt(slice_index start)
         if (!read_max_flights(tok))
         {
           OptFlag[solflights] = false;
-          output_plaintext_input_error_message(WrongInt,0);
+          output_plaintext_input_error_message(WrongInt);
           indexx = OptCount;
         }
         break;
@@ -257,7 +257,7 @@ char *ParseOpt(slice_index start)
         if (!read_max_nr_refutations(tok))
         {
           OptFlag[soltout] = false;
-          output_plaintext_input_error_message(WrongInt,0);
+          output_plaintext_input_error_message(WrongInt);
           indexx = OptCount;
         }
         break;
@@ -281,14 +281,14 @@ char *ParseOpt(slice_index start)
           else
           {
             OptFlag[nontrivial] = false;
-            output_plaintext_input_error_message(WrongInt, 0);
+            output_plaintext_input_error_message(WrongInt);
             indexx = OptCount;
           }
         }
         else
         {
           OptFlag[nontrivial] = false;
-          output_plaintext_input_error_message(WrongInt, 0);
+          output_plaintext_input_error_message(WrongInt);
           indexx = OptCount;
         }
         break;
@@ -309,7 +309,7 @@ char *ParseOpt(slice_index start)
 
         tok = ParseSquareList(squares_tok,&HandleNoCastlingSquare,0);
         if (tok==squares_tok)
-          output_plaintext_input_error_message(MissngSquareList,0);
+          output_plaintext_input_error_message(MissngSquareList);
         else if (*tok!=0)
           output_plaintext_error_message(WrongSquareList);
 
@@ -322,7 +322,7 @@ char *ParseOpt(slice_index start)
 
       case duplex:
         if (input_is_instrumented_with_duplex(start))
-          output_plaintext_input_error_message(InconsistentDuplexOption,0);
+          output_plaintext_input_error_message(InconsistentDuplexOption);
         else
         {
           input_instrument_duplex(start,STDuplexSolver);
@@ -332,7 +332,7 @@ char *ParseOpt(slice_index start)
 
       case halfduplex:
         if (input_is_instrumented_with_duplex(start))
-          output_plaintext_input_error_message(InconsistentDuplexOption,0);
+          output_plaintext_input_error_message(InconsistentDuplexOption);
         else
         {
           input_instrument_duplex(start,STHalfDuplexSolver);
@@ -389,7 +389,7 @@ char *ParseOpt(slice_index start)
   }
 
   if (OptCnt==0)
-    output_plaintext_input_error_message(UnrecOption,0);
+    output_plaintext_input_error_message(UnrecOption);
 
   TraceFunctionExit(__func__);
   TraceFunctionResult("%s",tok);

--- a/input/plaintext/pieces.c
+++ b/input/plaintext/pieces.c
@@ -236,7 +236,7 @@ static char *ParsePieceWalkAndSquares(char *tok, Flags Spec)
         char * const squares_tok = ReadNextTokStr();
         tok = ParseSquareList(squares_tok,&HandleAddedPiece,&settings);
         if (tok==squares_tok)
-          output_plaintext_input_error_message(MissngSquareList,0);
+          output_plaintext_input_error_message(MissngSquareList);
         else if (*tok!=0)
           output_plaintext_error_message(WrongSquareList);
       }
@@ -264,7 +264,7 @@ static char *ParsePieceWalkAndSquares(char *tok, Flags Spec)
     {
       if (nr_walks_parsed==0)
       {
-        output_plaintext_input_error_message(WrongPieceName,0);
+        output_plaintext_input_error_message(WrongPieceName);
         tok = ReadNextTokStr();
       }
       else
@@ -291,12 +291,12 @@ Flags ParseColour(char *tok, boolean colour_is_mandatory)
   if (colour==nr_colours)
   {
     if (colour_is_mandatory)
-      output_plaintext_input_error_message(NoColourSpec,0);
+      output_plaintext_input_error_message(NoColourSpec);
     return 0;
   }
   else if (colour>nr_colours)
   {
-    output_plaintext_input_error_message(PieSpecNotUniq,0);
+    output_plaintext_input_error_message(PieSpecNotUniq);
     return 0;
   }
   else if (colour==colour_neutral)
@@ -324,7 +324,7 @@ char *ParsePieceFlags(Flags *flags)
       if (ps==nr_piece_flags-nr_sides)
         break;
       else if (ps>nr_piece_flags-nr_sides)
-        output_plaintext_input_error_message(PieSpecNotUniq,0);
+        output_plaintext_input_error_message(PieSpecNotUniq);
       else
         SETFLAG(*flags,ps+nr_sides);
     }
@@ -354,7 +354,7 @@ char *ParsePieces(char *tok)
         unsigned long const value = strtoul(tok,&end,10);
         if (end==tok)
         {
-          output_plaintext_input_error_message(WrongInt,0);
+          output_plaintext_input_error_message(WrongInt);
           break;
         }
         else

--- a/input/plaintext/plaintext.c
+++ b/input/plaintext/plaintext.c
@@ -53,7 +53,7 @@ void input_plaintext_iterate_problems(slice_index si)
         break;
 
       default:
-        output_plaintext_input_error_message(ComNotUniq,0);
+        output_plaintext_input_error_message(ComNotUniq);
         break;
     }
   } while (!halt);
@@ -67,7 +67,7 @@ void input_plaintext_detect_user_language(slice_index si)
   UserLanguage = detect_user_language(ReadNextTokStr());
 
   if (UserLanguage==LanguageCount)
-    output_plaintext_input_error_message(NoBegOfProblem, 0);
+    output_plaintext_input_error_message(NoBegOfProblem);
   else
   {
     output_plaintext_select_language(UserLanguage);

--- a/input/plaintext/sstipulation.c
+++ b/input/plaintext/sstipulation.c
@@ -1194,7 +1194,7 @@ static Side ParseStructuredStip_starter(char *tok)
    * are initialised in terms of nr_sides */
   ps = GetUniqIndex(nr_sides,ColourTab,tok);
   if (ps>nr_sides)
-    output_plaintext_input_error_message(PieSpecNotUniq,0);
+    output_plaintext_input_error_message(PieSpecNotUniq);
   else if (ps<nr_sides)
     result = ps;
 

--- a/input/plaintext/stipulation.c
+++ b/input/plaintext/stipulation.c
@@ -83,11 +83,11 @@ static char *ParseReciGoal(char *tok,
           }
         }
         else
-          output_plaintext_input_error_message(UnrecStip, 0);
+          output_plaintext_input_error_message(UnrecStip);
       }
     }
     else
-      output_plaintext_input_error_message(UnrecStip, 0);
+      output_plaintext_input_error_message(UnrecStip);
   }
   else
   {
@@ -156,7 +156,7 @@ static char *ParseLength(char *tok, stip_length_type *length)
 
   if (tok==end || tmp_length>UINT_MAX)
   {
-    output_plaintext_input_error_message(WrongInt,0);
+    output_plaintext_input_error_message(WrongInt);
     tok = 0;
   }
   else
@@ -182,7 +182,7 @@ static char *ParseBattleLength(char *tok, stip_length_type *length)
   {
     if (*length==0)
     {
-      output_plaintext_input_error_message(WrongInt,0);
+      output_plaintext_input_error_message(WrongInt);
       tok = 0;
     }
     else
@@ -399,7 +399,7 @@ static char *ParseSeriesLength(char *tok,
   {
     if (*length==0)
     {
-      output_plaintext_input_error_message(WrongInt,0);
+      output_plaintext_input_error_message(WrongInt);
       tok = 0;
     }
     else
@@ -544,7 +544,7 @@ static char *ParsePlay(char *tok,
     char *end;
     unsigned long const intro_len= strtoul(tok,&end,10);
     if (intro_len<1 || tok==end || end!=arrowpos)
-      output_plaintext_input_error_message(WrongInt, 0);
+      output_plaintext_input_error_message(WrongInt);
     else
     {
       result = ParsePlay(arrowpos+2,start,proxy_next,play_length);
@@ -828,7 +828,7 @@ static char *ParsePlay(char *tok,
       if (length==1)
       {
         /* at least 2 half moves requried for a reciprocal stipulation */
-        output_plaintext_input_error_message(StipNotSupported,0);
+        output_plaintext_input_error_message(StipNotSupported);
         result = 0;
       }
 

--- a/input/plaintext/twin.c
+++ b/input/plaintext/twin.c
@@ -151,7 +151,7 @@ static char *ParseTwinningRotate(void)
   SquareTransformation const rotation = detect_rotation(tok);
 
   if (rotation==nr_square_transformation)
-    output_plaintext_input_error_message(UnrecRotMirr,0);
+    output_plaintext_input_error_message(UnrecRotMirr);
   else
     move_effect_journal_do_board_transformation(move_effect_reason_diagram_setup,
                                                 rotation);
@@ -165,7 +165,7 @@ static char *ParseTwinningMirror(void)
   TwinningMirrorType indexx = GetUniqIndex(TwinningMirrorCount,TwinningMirrorTab,tok);
 
   if (indexx>TwinningMirrorCount)
-    output_plaintext_input_error_message(OptNotUniq,0);
+    output_plaintext_input_error_message(OptNotUniq);
   else
   {
     switch (indexx)
@@ -191,7 +191,7 @@ static char *ParseTwinningMirror(void)
         break;
 
       default:
-        output_plaintext_input_error_message(UnrecRotMirr,0);
+        output_plaintext_input_error_message(UnrecRotMirr);
         break;
     }
   }
@@ -311,7 +311,7 @@ static char *ParseTwinningRemove(void)
   char * const squares_tok = ReadNextTokStr();
   char *tok = ParseSquareList(squares_tok,HandleRemovalSquare,0);
   if (tok==squares_tok)
-    output_plaintext_input_error_message(MissngSquareList,0);
+    output_plaintext_input_error_message(MissngSquareList);
   else if (*tok!=0)
     output_plaintext_error_message(WrongSquareList);
 
@@ -437,14 +437,14 @@ static char *ParseTwinningSubstitute(void)
   tok = ParsePieceWalkToken(tok,&p_old);
 
   if (p_old==nr_piece_walks)
-    output_plaintext_input_error_message(WrongPieceName,0);
+    output_plaintext_input_error_message(WrongPieceName);
   else
   {
     piece_walk_type p_new;
     tok = ParsePieceWalkToken(tok,&p_new);
 
     if (p_new==nr_piece_walks)
-      output_plaintext_input_error_message(WrongPieceName,0);
+      output_plaintext_input_error_message(WrongPieceName);
     else
     {
       /* we don't redo substitute twinnings */
@@ -545,7 +545,7 @@ static char *ParseTwinning(char *tok,
 
     if (twinning>TwinningCount)
     {
-      output_plaintext_input_error_message(ComNotUniq,0);
+      output_plaintext_input_error_message(ComNotUniq);
       tok = ReadNextTokStr();
     }
     else if (twinning==TwinningCount)
@@ -581,7 +581,7 @@ static char *ParseTwinning(char *tok,
             slice_index const stipulation_root_hook = input_find_stipulation(start);
             if (stipulation_root_hook==no_slice)
             {
-              output_plaintext_input_error_message(NoStipulation,0);
+              output_plaintext_input_error_message(NoStipulation);
               tok = 0;
             }
             else
@@ -599,7 +599,7 @@ static char *ParseTwinning(char *tok,
             slice_index const stipulation_root_hook = input_find_stipulation(start);
             if (stipulation_root_hook==no_slice)
             {
-              output_plaintext_input_error_message(NoStipulation,0);
+              output_plaintext_input_error_message(NoStipulation);
               tok = 0;
             }
             else
@@ -764,7 +764,7 @@ static char *ReadTrace(void)
     {
       FILE * const protocol = protocol_open(InputLine);
       if (protocol==0)
-        output_plaintext_input_error_message(WrOpenError,0);
+        output_plaintext_input_error_message(WrOpenError);
       else
         output_plaintext_print_version_info(protocol);
     }
@@ -856,16 +856,19 @@ static void ReadInitialTwin(slice_index start)
     result = GetUniqIndex(InitialTwinTokenCount,InitialTwinTokenTab,tok);
     if (result>InitialTwinTokenCount)
     {
-      output_plaintext_input_error_message(ComNotUniq,0);
+      output_plaintext_input_error_message(ComNotUniq);
       tok = ReadNextTokStr();
     }
     else if (result==InitialTwinTokenCount)
     {
       if (GetUniqIndex(ProblemTokenCount,ProblemTokenTab,tok)==ProblemTokenCount
           && GetUniqIndex(EndTwinTokenCount,EndTwinTokenTab,tok)==EndTwinTokenCount)
-        output_plaintext_input_error_message(OffendingItem,0);
-
-      break;
+      {
+        output_plaintext_input_error_message(OffendingItem,tok);
+        tok = ReadNextTokStr();
+      }
+      else
+        break;
     }
     else
       switch (result)
@@ -877,7 +880,7 @@ static void ReadInitialTwin(slice_index start)
           {
             slice_index const root_slice_hook = input_find_stipulation(start);
             if (root_slice_hook==no_slice)
-              output_plaintext_input_error_message(UnrecStip,0);
+              output_plaintext_input_error_message(UnrecStip);
           }
           break;
         }
@@ -889,7 +892,7 @@ static void ReadInitialTwin(slice_index start)
           {
             slice_index const root_slice_hook = input_find_stipulation(start);
             if (root_slice_hook==no_slice)
-              output_plaintext_input_error_message(UnrecStip,0);
+              output_plaintext_input_error_message(UnrecStip);
           }
           break;
         }
@@ -1002,7 +1005,7 @@ static char *ReadSubsequentTwin(char *tok, slice_index start, unsigned int twin_
     InitialTwinToken const result = GetUniqIndex(SubsequentTwinTokenCount,InitialTwinTokenTab,tok);
     if (result>SubsequentTwinTokenCount)
     {
-      output_plaintext_input_error_message(ComNotUniq,0);
+      output_plaintext_input_error_message(ComNotUniq);
       tok = ReadNextTokStr();
     }
     else if (result==SubsequentTwinTokenCount)
@@ -1218,7 +1221,7 @@ static char *twins_handle(char *tok, slice_index si)
       EndTwinToken const endToken = GetUniqIndex(EndTwinTokenCount,EndTwinTokenTab,tok);
 
       if (endToken>EndTwinTokenCount)
-        output_plaintext_input_error_message(ComNotUniq,0);
+        output_plaintext_input_error_message(ComNotUniq);
       else
       {
         pipe_solve_delegate(si);
@@ -1297,7 +1300,7 @@ void input_plaintext_twins_handle(slice_index si)
       break;
 
     default:
-      output_plaintext_input_error_message(ComNotUniq,0);
+      output_plaintext_input_error_message(ComNotUniq);
       tok = ReadNextTokStr();
       break;
   }
@@ -1320,7 +1323,7 @@ void input_plaintext_initial_twin_reader_solve(slice_index si)
   {
     slice_index const stipulation_root_hook = input_find_stipulation(si);
     if (stipulation_root_hook==no_slice)
-      output_plaintext_input_error_message(NoStipulation,0);
+      output_plaintext_input_error_message(NoStipulation);
     else
     {
       stipulation_modifiers_notify(si,stipulation_root_hook);

--- a/output/latex/latex.c
+++ b/output/latex/latex.c
@@ -264,7 +264,7 @@ void LaTeXSetup(slice_index start)
 
     SLICE_U(file_owner).writer.file = fopen(InputLine,"w");
     if (SLICE_U(file_owner).writer.file==NULL)
-      output_plaintext_input_error_message(WrOpenError,0);
+      output_plaintext_input_error_message(WrOpenError);
     else
       WriteIntro(SLICE_U(file_owner).writer.file);
   }

--- a/output/plaintext/message.c
+++ b/output/plaintext/message.c
@@ -98,15 +98,18 @@ void output_plaintext_verifie_message(message_id_t id)
 
 /* Issue an input error message
  * @param id identifies the diagnostic message
- * @param val additional parameter according to the printf() conversion
+ * @param ... additional parameters according to the printf() conversion
  *            specifier in message id
  */
-void output_plaintext_input_error_message(message_id_t n, int val)
+void output_plaintext_input_error_message(message_id_t n, ...)
 {
 #if !defined(QUIET)
+  va_list args;
   protocol_fflush(stdout);
-  output_plaintext_error_message(InputError,val);
-  output_plaintext_error_message(n);
+  output_plaintext_error_message(InputError);
+  va_start(args,n);
+  output_plaintext_error_message(n,args);
+  va_end(args);
   protocol_fputc('\n',stderr);
   output_plaintext_error_message(OffendingItem,InputLine);
   protocol_fputc('\n',stderr);

--- a/output/plaintext/message.h
+++ b/output/plaintext/message.h
@@ -38,10 +38,10 @@ void output_plaintext_fatal_message(message_id_t id);
 
 /* Issue an input error message
  * @param id identifies the diagnostic message
- * @param val additional parameter according to the printf() conversion
+ * @param ... additional parameters according to the printf() conversion
  *            specifier in message id
  */
-void output_plaintext_input_error_message(message_id_t n, int val);
+void output_plaintext_input_error_message(message_id_t n, ...);
 
 /* Issue a solving time indication
  * @param header text printed before the time

--- a/solving/proofgames.c
+++ b/solving/proofgames.c
@@ -385,7 +385,7 @@ void input_instrument_proof(slice_index start)
   TraceFunctionParamListEnd();
 
   if (input_is_instrumented_with_proof(start))
-    output_plaintext_input_error_message(InconsistentProofTarget,0);
+    output_plaintext_input_error_message(InconsistentProofTarget);
   else
   {
     slice_index const prototypes[] = {


### PR DESCRIPTION
The problem was that `output_plaintext_input_error_message` was mis-specified and mis-defined. It really needs to take and pass along `var_args` to go along with the intended message. I've fixed this function and updated calls throughout the codebase accordingly.