### PR TITLE
Eliminating some invalid shifts.

### DIFF
--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -418,12 +418,12 @@ static void init_slice_properties_attack_hashed(slice_index si,
   assert(sis->nrBitsLeft>=size);
   sis->nrBitsLeft -= size;
   slice_properties[si].u.d.offsetNoSucc = sis->nrBitsLeft;
-  slice_properties[si].u.d.maskNoSucc = mask << sis->nrBitsLeft;
+  slice_properties[si].u.d.maskNoSucc = ((sis->nrBitsLeft < (CHAR_BIT * (sizeof mask))) ? (mask << sis->nrBitsLeft) : 0);
 
   assert(sis->nrBitsLeft>=size);
   sis->nrBitsLeft -= size;
   slice_properties[si].u.d.offsetSucc = sis->nrBitsLeft;
-  slice_properties[si].u.d.maskSucc = mask << sis->nrBitsLeft;
+  slice_properties[si].u.d.maskSucc = ((sis->nrBitsLeft < (CHAR_BIT * (sizeof mask))) ? (mask << sis->nrBitsLeft) : 0);
 
   hash_slices[nr_hash_slices++] = si;
   stip_traverse_structure_children_pipe(si,st);
@@ -606,7 +606,7 @@ static void set_value_attack_nosuccess(hashElement_union_t *hue,
                                        hash_value_type val)
 {
   unsigned int const offset = slice_properties[si].u.d.offsetNoSucc;
-  unsigned int const bits = val << offset;
+  unsigned int const bits = ((offset < (CHAR_BIT * (sizeof val))) ? (val << offset) : 0);
   unsigned int const mask = slice_properties[si].u.d.maskNoSucc;
   element_t * const e = &hue->e;
   TraceFunctionEntry(__func__);
@@ -634,7 +634,7 @@ static void set_value_attack_success(hashElement_union_t *hue,
                                      hash_value_type val)
 {
   unsigned int const offset = slice_properties[si].u.d.offsetSucc;
-  unsigned int const bits = val << offset;
+  unsigned int const bits = ((offset < (CHAR_BIT * (sizeof val))) ? (val << offset) : 0);
   unsigned int const mask = slice_properties[si].u.d.maskSucc;
   element_t * const e = &hue->e;
 


### PR DESCRIPTION
Shifting an integer by its width in bits (or more) is [undefined](https://en.wikipedia.org/wiki/Undefined_behavior#Examples_in_C_and_C++).  Alas, Popeye will attempt this when running over some of the example files (e.g., `EXAMPLES/marine.inp`, `EXAMPLES/republican.inp`, and `EXAMPLES/magicpieces.inp`).  I've gone ahead and updated the code with what _I think_ is the intended behavior.  Of course, it's possible that I've guessed wrong and/or that these oversized shifts are symptomatic of some deeper issue.