### PR TITLE
Fixing void function prototypes

### DIFF
--- a/DHT/dht.c
+++ b/DHT/dht.c
@@ -426,7 +426,7 @@ unsigned long dhtKeyCount(dht *h)
 
 char dhtError[128];
 
-char const *dhtErrorMsg()
+char const *dhtErrorMsg(void)
 {
   return dhtError;
 }

--- a/DHT/dht.h
+++ b/DHT/dht.h
@@ -36,7 +36,7 @@ dhtElement   *dhtLookupElement	(struct dht *, dhtConstValue key);
 dhtElement   *dhtGetFirstElement(struct dht *);
 dhtElement   *dhtGetNextElement	(struct dht *);
 unsigned long dhtKeyCount	(struct dht *);
-char const   *dhtErrorMsg	();
+char const   *dhtErrorMsg	(void);
 
 extern char dhtError[];
 

--- a/DHT/fxf.c
+++ b/DHT/fxf.c
@@ -423,7 +423,7 @@ void *fxfReAlloc(void *ptr, size_t OldSize, size_t NewSize) {
   return nptr;
 }
 
-size_t fxfTotal() {
+size_t fxfTotal(void) {
   SizeHead const *hd = SizeData;
   size_t UsedBytes = 0;
   size_t FreeBytes = 0;

--- a/DHT/fxf.h
+++ b/DHT/fxf.h
@@ -9,7 +9,7 @@ void *fxfAlloc(size_t size);
 void *fxfReAlloc(void *ptr, size_t OldSize, size_t NewSize);
 void fxfFree(void *ptr, size_t size);
 void fxfInfo(FILE *);
-size_t fxfTotal();
+size_t fxfTotal(void);
 
 /* Reset the internal data structures to the state that was reached
  * after the latest call to fxfInit() */

--- a/conditions/patience.c
+++ b/conditions/patience.c
@@ -14,7 +14,7 @@
 boolean PatienceB;
 static square sqdep[maxply+1];
 
-static boolean patience_legal()
+static boolean patience_legal(void)
 {
   square bl_last_vacated = initsquare;
   square wh_last_vacated = initsquare;

--- a/optimisations/killer_move/collector.c
+++ b/optimisations/killer_move/collector.c
@@ -9,7 +9,7 @@
 
 #include "debugging/assert.h"
 
-static void remember_killer_move()
+static void remember_killer_move(void)
 {
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();

--- a/optimisations/orthodox_mating_moves/orthodox_mating_move_generator.c
+++ b/optimisations/orthodox_mating_moves/orthodox_mating_move_generator.c
@@ -465,7 +465,7 @@ static void bishop(square sq_king, Side side)
   }
 }
 
-static void generate_move_reaching_goal()
+static void generate_move_reaching_goal(void)
 {
   square square_a = square_a1;
   Side const side_at_move = trait[nbply];

--- a/platform/dos/priority.c
+++ b/platform/dos/priority.c
@@ -1,6 +1,6 @@
 #include "platform/priority.h"
 
-void platform_set_nice_priority()
+void platform_set_nice_priority(void)
 {
   /* What to do? Nothing is nice on DOS ...
    */

--- a/platform/priority.h
+++ b/platform/priority.h
@@ -8,6 +8,6 @@
 /* Set the priority of Popeye's main process to a level that causes
  * Popeye to "play" nicely.
  */
-void platform_set_nice_priority();
+void platform_set_nice_priority(void);
 
 #endif

--- a/platform/unix/priority.c
+++ b/platform/unix/priority.c
@@ -1,6 +1,6 @@
 #include "platform/priority.h"
 
-void platform_set_nice_priority()
+void platform_set_nice_priority(void)
 {
   /* Nothing to be done here. Everything is nice on Unix, and if not,
    * users know how to change that, even if there's no such thing as a

--- a/platform/windows32/priority.c
+++ b/platform/windows32/priority.c
@@ -15,7 +15,7 @@ enum dummy
   BELOW_NORMAL_PRIORITY_CLASS = 0x4000
 };
 
-void platform_set_nice_priority()
+void platform_set_nice_priority(void)
 {
   SetPriorityClass(GetCurrentProcess(),
                    BELOW_NORMAL_PRIORITY_CLASS);

--- a/platform/windows64/priority.c
+++ b/platform/windows64/priority.c
@@ -1,7 +1,7 @@
 #include "platform/priority.h"
 #include <windows.h>
 
-void platform_set_nice_priority()
+void platform_set_nice_priority(void)
 {
   /* BELOW_NORMAL_PRIORITY_CLASS:
    * Process that has priority above * IDLE_PRIORITY_CLASS but below


### PR DESCRIPTION
To specify that a function takes _no_ arguments, C requires that one declare it as something like
```
int f(void);
```
while a declaration like
```
int f();
```
simply doesn't tell the compiler what's needed.  (In C++, the latter also works.)  Specifying this correctly should provide at least a small performance benefit while allowing the compiler to catch calls that attempt to pass arguments.  I've gone ahead and fixed all the cases I could find.