### PR TITLE
Const-correctness

### DIFF
--- a/DHT/dht.c
+++ b/DHT/dht.c
@@ -677,7 +677,7 @@ LOCAL uLong DynamicHash(uLong p, uLong maxp, dhtHashValue v)
 
 LOCAL dhtStatus ExpandHashTable(HashTable *ht)
 {
-  static char *myname= "ExpandHashTable";
+  static char const *myname= "ExpandHashTable";
   /* Need to expand the directory */
   uLong oldp= ht->p;
   uLong newp= ht->maxp + ht->p;
@@ -985,7 +985,7 @@ int dhtBucketStat(HashTable *ht, unsigned int *counter, unsigned int n)
   while (he!=Nil(dhtElement))
   {
     unsigned int len = 1;
-    InternHsElement *ihe = ((InternHsElement *)he)->Next;
+    InternHsElement *ihe = ((InternHsElement const *)he)->Next;
     while (ihe!=0)
     {
       ++len;

--- a/DHT/dhtbcmem.c
+++ b/DHT/dhtbcmem.c
@@ -24,7 +24,7 @@
 
 static dhtHashValue ConvertBCMemValue(dhtConstValue m)
 {
-  BCMemValue const * const toBeConverted = (BCMemValue *)m;
+  BCMemValue const * const toBeConverted = (BCMemValue const *)m;
   unsigned int leng = toBeConverted->Leng;
   unsigned char const *s = toBeConverted->Data;
   dhtHashValue hash = 0;
@@ -46,8 +46,8 @@ static dhtHashValue ConvertBCMemValue(dhtConstValue m)
 
 static int EqualBCMemValue(dhtConstValue v1, dhtConstValue v2)
 {
-  BCMemValue const * const value1 = (BCMemValue *)v1;
-  BCMemValue const * const value2 = (BCMemValue *)v2;
+  BCMemValue const * const value1 = (BCMemValue const *)v1;
+  BCMemValue const * const value2 = (BCMemValue const *)v2;
   size_t const size = sizeof *value1 - sizeof value1->Data + value1->Leng;
 
   return memcmp(value1,value2,size)==0;
@@ -55,7 +55,7 @@ static int EqualBCMemValue(dhtConstValue v1, dhtConstValue v2)
 
 static dhtValue DupBCMemValue(dhtConstValue v)
 {
-  BCMemValue const * const original = (BCMemValue *)v;
+  BCMemValue const * const original = (BCMemValue const *)v;
   size_t const size = (sizeof *original
                        - sizeof original->Data
                        + original->Leng);
@@ -76,7 +76,7 @@ static void FreeBCMemVal(dhtValue v)
 
 static void DumpBCMemValue(dhtConstValue v, FILE *f)
 {
-  BCMemValue const * const toBeDumped = (BCMemValue *)v;
+  BCMemValue const * const toBeDumped = (BCMemValue const *)v;
   unsigned int const length = toBeDumped->Leng;
   unsigned int i;
 

--- a/DHT/dhtcmem.c
+++ b/DHT/dhtcmem.c
@@ -24,8 +24,8 @@ typedef unsigned char uChar;
 
 static dhtHashValue  ConvertCompactMemoryValue(dhtConstValue m)
 {
-  uLong leng= ((CompactMemVal *)m)->Leng;
-  uChar *s= ((CompactMemVal *)m)->Data;
+  uLong leng= ((CompactMemVal const *)m)->Leng;
+  uChar const *s= ((CompactMemVal const *)m)->Data;
   dhtHashValue hash= 0;
   uLong i;
   for (i=0; i<leng; i++) {
@@ -41,10 +41,10 @@ static dhtHashValue  ConvertCompactMemoryValue(dhtConstValue m)
 
 static int EqualCompactMemoryValue(dhtConstValue v1, dhtConstValue v2)
 {
-  if (((CompactMemVal *)v1)->Leng != ((CompactMemVal *)v2)->Leng)
+  if (((CompactMemVal const *)v1)->Leng != ((CompactMemVal const *)v2)->Leng)
     return 0;
-  if (memcmp(((CompactMemVal *)v1)->Data,
-             ((CompactMemVal *)v2)->Data, ((CompactMemVal *)v1)->Leng))
+  if (memcmp(((CompactMemVal const *)v1)->Data,
+             ((CompactMemVal const *)v2)->Data, ((CompactMemVal const *)v1)->Leng))
     return 0;
   else
     return 1;
@@ -52,10 +52,10 @@ static int EqualCompactMemoryValue(dhtConstValue v1, dhtConstValue v2)
 
 static dhtValue DupCompactMemoryValue(dhtConstValue v)
 {
-  CompactMemVal *cm= NewCompactMemVal(((CompactMemVal *)v)->Leng);
+  CompactMemVal *cm= NewCompactMemVal(((CompactMemVal const *)v)->Leng);
   if (cm) {
-    cm->Leng= ((CompactMemVal *)v)->Leng;
-    memcpy(cm->Data, ((CompactMemVal *)v)->Data, cm->Leng);
+    cm->Leng= ((CompactMemVal const *)v)->Leng;
+    memcpy(cm->Data, ((CompactMemVal const *)v)->Data, cm->Leng);
     return (dhtValue)cm;
   }
   return (dhtValue)cm;
@@ -70,9 +70,9 @@ static void FreeCompactMemoryValue(dhtValue v)
 static void DumpCompactMemoryValue(dhtConstValue v, FILE *f)
 {
   uLong i;
-  fprintf(f, "(%lu)", ((CompactMemVal *)v)->Leng);
-  for (i=0; i<((CompactMemVal*)v)->Leng; i++)
-    fprintf(f, "%02x", ((CompactMemVal*)v)->Data[i] & 0xff);
+  fprintf(f, "(%lu)", ((CompactMemVal const *)v)->Leng);
+  for (i=0; i<((CompactMemVal const *)v)->Leng; i++)
+    fprintf(f, "%02x", ((CompactMemVal const *)v)->Data[i] & 0xff);
   return;
 }
 

--- a/DHT/dhtmem.c
+++ b/DHT/dhtmem.c
@@ -25,8 +25,8 @@ typedef unsigned char uChar;
 
 static dhtHashValue HashMemoryValue(dhtConstValue v)
 {
-  uLong leng= ((MemVal*)v)->Leng;
-  uChar *s= ((MemVal*)v)->Data;
+  uLong leng= ((MemVal const *)v)->Leng;
+  uChar const *s= ((MemVal const *)v)->Data;
   dhtHashValue hash= 0;
   uLong i;
   for (i=0; i<leng; i++) {
@@ -41,9 +41,9 @@ static dhtHashValue HashMemoryValue(dhtConstValue v)
 }
 static int EqualMemoryValue(dhtConstValue v1, dhtConstValue v2)
 {
-  if (((MemVal*)v1)->Leng != ((MemVal*)v2)->Leng)
+  if (((MemVal const *)v1)->Leng != ((MemVal const *)v2)->Leng)
     return 0;
-  if (memcmp(((MemVal*)v1)->Data, ((MemVal*)v2)->Data, ((MemVal*)v1)->Leng))
+  if (memcmp(((MemVal const *)v1)->Data, ((MemVal const *)v2)->Data, ((MemVal const *)v1)->Leng))
     return 0;
   else
     return 1;
@@ -55,7 +55,7 @@ static dhtValue	DupMemoryValue(dhtConstValue v)
 
   mv= NewMemVal;
   if (mv) {
-    mv->Data= (unsigned char *)fxfAlloc(((MemVal*)v)->Leng);
+    mv->Data= (unsigned char *)fxfAlloc(((MemVal const *)v)->Leng);
     if (!mv->Data)
       FreeMemVal(mv);
     else {
@@ -73,9 +73,9 @@ static void	FreeMemoryValue(dhtValue v)
 }
 static void	DumpMemoryValue(dhtConstValue v, FILE *f) {
   uLong i;
-  fprintf(f, "(%lu)", ((MemVal*)v)->Leng);
-  for (i=0; i<((MemVal*)v)->Leng; i++)
-    fprintf(f, "%02x", ((MemVal*)v)->Data[i] & 0xff);
+  fprintf(f, "(%lu)", ((MemVal const *)v)->Leng);
+  for (i=0; i<((MemVal const *)v)->Leng; i++)
+    fprintf(f, "%02x", ((MemVal const *)v)->Data[i] & 0xff);
   return;
 }
 

--- a/DHT/dhtstrng.c
+++ b/DHT/dhtstrng.c
@@ -23,7 +23,7 @@ static unsigned long ConvertString(dhtConstValue v)
      *	  - independant from word sizes
      *	  - needs no initialisation
      */
-    unsigned char *s= (unsigned char *)v;
+    unsigned char const *s= (unsigned char const *)v;
     unsigned long hash= 0;
     while (*s) {
 	hash+= *s++;
@@ -38,7 +38,7 @@ static unsigned long ConvertString(dhtConstValue v)
 
 static int EqualString(dhtConstValue v1, dhtConstValue v2)
 {
-	if (strcmp((char *)v1, (char *)v2))
+	if (strcmp((char const *)v1, (char const *)v2))
 		return 0;
 	else
 		return 1;
@@ -47,19 +47,19 @@ static int EqualString(dhtConstValue v1, dhtConstValue v2)
 static dhtValue	DupString(dhtConstValue v)
 {
 	char *nv;
-	nv= (char *)fxfAlloc(strlen((char *)v)+1);
+	nv= (char *)fxfAlloc(strlen((char const *)v)+1);
 	if (nv!=0)
-      strcpy(nv, (char *)v);
+		strcpy(nv, (char const *)v);
 	return (dhtValue)nv;
 }
 static void	FreeString(dhtValue v)
 {
-	fxfFree(v, strlen((char *)v)+1);
+	fxfFree(v, strlen((char const *)v)+1);
 	return;
 }
 static void	DumpString(dhtConstValue v, FILE *f)
 {
-	fputs((char *)v,f);
+	fputs((char const *)v,f);
 	return;
 }
 

--- a/DHT/dhtvalue.h
+++ b/DHT/dhtvalue.h
@@ -56,7 +56,7 @@ typedef enum {
 	dhtValueTypeCnt
 } dhtValueType;
 
-DATA char *dhtValueTypeToString[dhtValueTypeCnt]
+DATA char const *dhtValueTypeToString[dhtValueTypeCnt]
 #if defined(GDATA)
 	= { "dhtSimpleValue",
 	    "dhtStringValue",

--- a/output/latex/latex.c
+++ b/output/latex/latex.c
@@ -32,7 +32,7 @@
 
 static char *LaTeXPiecesAbbr[nr_piece_walks];
 static char *LaTeXPiecesFull[nr_piece_walks];
-char *LaTeXStdPie[8] = { NULL, "C", "K", "B", "D", "S", "T", "L"};
+char const *LaTeXStdPie[8] = { NULL, "C", "K", "B", "D", "S", "T", "L"};
 
 static char const CharChar[] = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -52,7 +52,7 @@ output_symbol_table_type const output_latex_symbol_table =
     "{\\00}"
 };
 
-char *LaTeXWalk(piece_walk_type walk)
+char const *LaTeXWalk(piece_walk_type walk)
 {
   if (walk > Bishop)
   {

--- a/output/latex/latex.h
+++ b/output/latex/latex.h
@@ -34,7 +34,7 @@ char *ParseLaTeXPieces(void);
 
 void LaTeXStr(FILE *file, char const *line);
 void LaTeXCopyFile(FILE *src, FILE *dest, int size);
-char *LaTeXWalk(piece_walk_type walk);
+char const *LaTeXWalk(piece_walk_type walk);
 
 void WriteUserInputElement(FILE *file, char const *name, char const *value);
 

--- a/pieces/attributes/total_invisible/revelations.c
+++ b/pieces/attributes/total_invisible/revelations.c
@@ -146,7 +146,7 @@ static void do_revelation_of_new_invisible(move_effect_reason_type reason,
   TraceFunctionResultEnd();
 }
 
-void reveal_new(move_effect_journal_entry_type const *entry)
+void reveal_new(move_effect_journal_entry_type *entry)
 {
   square const on = entry->u.piece_addition.added.on;
   piece_walk_type const walk = entry->u.piece_addition.added.walk;
@@ -182,7 +182,7 @@ void reveal_new(move_effect_journal_entry_type const *entry)
   TraceFunctionResultEnd();
 }
 
-void unreveal_new(move_effect_journal_entry_type const *entry)
+void unreveal_new(move_effect_journal_entry_type *entry)
 {
   square const on = entry->u.piece_addition.added.on;
   piece_walk_type const walk = entry->u.piece_addition.added.walk;
@@ -1347,7 +1347,7 @@ void undo_revelation_effects(move_effect_journal_index_type curr)
   }
   else
   {
-    move_effect_journal_entry_type const * const entry = &move_effect_journal[curr-1];
+    move_effect_journal_entry_type * const entry = &move_effect_journal[curr-1];
 
     TraceValue("%u",entry->type);TraceEOL();
     switch (entry->type)

--- a/pieces/attributes/total_invisible/revelations.c
+++ b/pieces/attributes/total_invisible/revelations.c
@@ -166,7 +166,7 @@ void reveal_new(move_effect_journal_entry_type *entry)
 
   replace_walk(on,walk);
 
-  ((move_effect_journal_entry_type *)entry)->u.piece_addition.added.flags = being_solved.spec[on];
+  entry->u.piece_addition.added.flags = being_solved.spec[on];
   being_solved.spec[on] = spec;
 
   if (TSTFLAG(spec,Royal) && walk==King)
@@ -199,7 +199,7 @@ void unreveal_new(move_effect_journal_entry_type *entry)
   if (TSTFLAG(being_solved.spec[on],Royal) && walk==King)
     being_solved.king_square[side_revealed] = initsquare;
 
-  ((move_effect_journal_entry_type *)entry)->u.piece_addition.added.flags = being_solved.spec[on];
+  entry->u.piece_addition.added.flags = being_solved.spec[on];
   being_solved.spec[on] = spec;
 
   replace_walk(on,Dummy);

--- a/pieces/attributes/total_invisible/revelations.h
+++ b/pieces/attributes/total_invisible/revelations.h
@@ -41,8 +41,8 @@ PieceIdType initialise_motivation(purpose_type purpose, square sq_first,
 PieceIdType initialise_motivation_from_revelation(revelation_status_type const *revelation);
 void uninitialise_motivation(PieceIdType id_uninitialised);
 
-void reveal_new(move_effect_journal_entry_type const *entry);
-void unreveal_new(move_effect_journal_entry_type const *entry);
+void reveal_new(move_effect_journal_entry_type *entry);
+void unreveal_new(move_effect_journal_entry_type *entry);
 
 void reveal_placed(move_effect_journal_entry_type const *entry);
 void unreveal_placed(move_effect_journal_entry_type const *entry);


### PR DESCRIPTION
I've eliminated any unnecessary casts from `const` to non-`const` data that I could find.  (This was basically all of them, though in a couple of cases it was the labeling of the data as `const` in the first placed that was incorrect/unnecessary.)  As a result, I'm (now) fairly confident that `const` data isn't being modified anywhere, and future `const`-violation will stand out more clearly among compiler warnings.