### PR TITLE
Feature/eliminate hash punning

### DIFF
--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -84,19 +84,19 @@
 #if (defined __STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
 #  include <stdint.h>
 #  ifdef UINTPTR_MAX
-typedef uintptr_t uint_pointer_t;
+typedef uintptr_t uint_pointer_type;
 #  else
-typedef uintmax_t uint_pointer_t;
+typedef uintmax_t uint_pointer_type;
 #  endif
 #elif (defined __cplusplus) && (__cplusplus >= 201103L)
 #  include <cstdint>
 #  ifdef UINTPTR_MAX
-typedef std::uintptr_t uint_pointer_t;
+typedef std::uintptr_t uint_pointer_type;
 #  else
-typedef std::uintmax_t uint_pointer_t;
+typedef std::uintmax_t uint_pointer_type;
 #  endif
 #else
-typedef unsigned long uint_pointer_t;
+typedef unsigned long uint_pointer_type;
 #endif
 
 #include <memory.h>
@@ -671,11 +671,11 @@ static void set_value_attack_nosuccess(dhtElement *hue,
   TraceValue("%08x",bits);
   TraceEOL();
   assert((bits&mask)==bits);
-  tmp = (data_type)(uint_pointer_t)hue->Data;
+  tmp = (data_type)(uint_pointer_type)hue->Data;
   tmp &= ~mask;
   tmp |= bits;
-  hue->Data = (dhtConstValue)(uint_pointer_t)tmp;
-  TraceValue("post:%08x",(unsigned int)(uint_pointer_t)hue->Data);
+  hue->Data = (dhtConstValue)(uint_pointer_type)tmp;
+  TraceValue("post:%08x",(unsigned int)(uint_pointer_type)hue->Data);
   TraceEOL();
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -703,11 +703,11 @@ static void set_value_attack_success(dhtElement *hue,
   TraceValue("%08x",bits);
   TraceEOL();
   assert((bits&mask)==bits);
-  tmp = (data_type)(uint_pointer_t)hue->Data;
+  tmp = (data_type)(uint_pointer_type)hue->Data;
   tmp &= ~mask;
   tmp |= bits;
-  hue->Data = (dhtConstValue)(uint_pointer_t)tmp;
-  TraceValue("post:%08x",(unsigned int)(uint_pointer_t)hue->Data);
+  hue->Data = (dhtConstValue)(uint_pointer_type)tmp;
+  TraceValue("post:%08x",(unsigned int)(uint_pointer_type)hue->Data);
   TraceEOL();
 
   TraceFunctionExit(__func__);
@@ -734,10 +734,10 @@ static void set_value_help(dhtElement *hue,
   TraceValue("0x%08x",bits);
   TraceEOL();
   assert((bits&mask)==bits);
-  tmp = (data_type)(uint_pointer_t)hue->Data;
+  tmp = (data_type)(uint_pointer_type)hue->Data;
   tmp &= ~mask;
   tmp |= bits;
-  hue->Data = (dhtConstValue)(uint_pointer_t)tmp;
+  hue->Data = (dhtConstValue)(uint_pointer_type)tmp;
   TraceValue("post:0x%08x",(unsigned int)hue->Data);
   TraceEOL();
   TraceFunctionExit(__func__);
@@ -749,12 +749,12 @@ static hash_value_type get_value_attack_success(dhtElement const *hue,
 {
   unsigned int const offset = slice_properties[si].u.d.offsetSucc;
   unsigned int const mask = slice_properties[si].u.d.maskSucc;
-  data_type const result = (mask & (data_type)(uint_pointer_t)hue->Data) >> offset;
+  data_type const result = (mask & (data_type)(uint_pointer_type)hue->Data) >> offset;
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",si);
   TraceValue("%08x ",mask);
   TraceValue("%p",(void *)&hue->Data);
-  TraceValue("%08x",(unsigned int)(uint_pointer_t)hue->Data);
+  TraceValue("%08x",(unsigned int)(uint_pointer_type)hue->Data);
   TraceEOL();
 
   TraceFunctionExit(__func__);
@@ -768,12 +768,12 @@ static hash_value_type get_value_attack_nosuccess(dhtElement const *hue,
 {
   unsigned int const offset = slice_properties[si].u.d.offsetNoSucc;
   unsigned int const mask = slice_properties[si].u.d.maskNoSucc;
-  data_type const result = (mask & (data_type)(uint_pointer_t)hue->Data) >> offset;
+  data_type const result = (mask & (data_type)(uint_pointer_type)hue->Data) >> offset;
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",si);
   TraceValue("%08x ",mask);
   TraceValue("%p",(void *)&hue->Data);
-  TraceValue("%08x",(unsigned int)(uint_pointer_t)hue->Data);
+  TraceValue("%08x",(unsigned int)(uint_pointer_type)hue->Data);
   TraceEOL();
 
   TraceFunctionExit(__func__);
@@ -787,13 +787,13 @@ static hash_value_type get_value_help(dhtElement const *hue,
 {
   unsigned int const offset = slice_properties[si].u.h.offsetNoSucc;
   unsigned int const  mask = slice_properties[si].u.h.maskNoSucc;
-  data_type const result = (mask & (data_type)(uint_pointer_t)hue->Data) >> offset;
+  data_type const result = (mask & (data_type)(uint_pointer_type)hue->Data) >> offset;
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",si);
   TraceValue("%u",offset);
   TraceValue("0x%08x ",mask);
   TraceValue("%p ",(void *)&hue->Data);
-  TraceValue("0x%08x",(unsigned int)(uint_pointer_t)hue->Data);
+  TraceValue("0x%08x",(unsigned int)(uint_pointer_type)hue->Data);
   TraceEOL();
 
   TraceFunctionExit(__func__);

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -81,6 +81,23 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
+#if (defined __STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+#  include <stdint.h>
+#  ifdef UINTPTR_MAX
+typedef uintptr_t uint_pointer_t;
+#  else
+typedef uintmax_t uint_pointer_t;
+#  endif
+#elif (defined __cplusplus) && (__cplusplus >= 201103L)
+#  include <cstdint>
+#  ifdef UINTPTR_MAX
+typedef std::uintptr_t uint_pointer_t;
+#  else
+typedef std::uintmax_t uint_pointer_t;
+#  endif
+#else
+typedef unsigned long uint_pointer_t;
+#endif
 
 #include <memory.h>
 #include "optimisations/hash.h"
@@ -654,11 +671,11 @@ static void set_value_attack_nosuccess(dhtElement *hue,
   TraceValue("%08x",bits);
   TraceEOL();
   assert((bits&mask)==bits);
-  tmp = (data_type)hue->Data;
+  tmp = (data_type)(uint_pointer_t)hue->Data;
   tmp &= ~mask;
   tmp |= bits;
-  hue->Data = (dhtConstValue)tmp;
-  TraceValue("post:%08x",(unsigned int)hue->Data);
+  hue->Data = (dhtConstValue)(uint_pointer_t)tmp;
+  TraceValue("post:%08x",(unsigned int)(uint_pointer_t)hue->Data);
   TraceEOL();
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -686,11 +703,11 @@ static void set_value_attack_success(dhtElement *hue,
   TraceValue("%08x",bits);
   TraceEOL();
   assert((bits&mask)==bits);
-  tmp = (data_type)hue->Data;
+  tmp = (data_type)(uint_pointer_t)hue->Data;
   tmp &= ~mask;
   tmp |= bits;
-  hue->Data = (dhtConstValue)tmp;
-  TraceValue("post:%08x",(unsigned int)hue->Data);
+  hue->Data = (dhtConstValue)(uint_pointer_t)tmp;
+  TraceValue("post:%08x",(unsigned int)(uint_pointer_t)hue->Data);
   TraceEOL();
 
   TraceFunctionExit(__func__);
@@ -717,10 +734,10 @@ static void set_value_help(dhtElement *hue,
   TraceValue("0x%08x",bits);
   TraceEOL();
   assert((bits&mask)==bits);
-  tmp = (data_type)hue->Data;
+  tmp = (data_type)(uint_pointer_t)hue->Data;
   tmp &= ~mask;
   tmp |= bits;
-  hue->Data = (dhtConstValue)tmp;
+  hue->Data = (dhtConstValue)(uint_pointer_t)tmp;
   TraceValue("post:0x%08x",(unsigned int)hue->Data);
   TraceEOL();
   TraceFunctionExit(__func__);
@@ -732,12 +749,12 @@ static hash_value_type get_value_attack_success(dhtElement const *hue,
 {
   unsigned int const offset = slice_properties[si].u.d.offsetSucc;
   unsigned int const mask = slice_properties[si].u.d.maskSucc;
-  data_type const result = (mask & (data_type)hue->Data) >> offset;
+  data_type const result = (mask & (data_type)(uint_pointer_t)hue->Data) >> offset;
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",si);
   TraceValue("%08x ",mask);
   TraceValue("%p",(void *)&hue->Data);
-  TraceValue("%08x",(unsigned int)hue->Data);
+  TraceValue("%08x",(unsigned int)(uint_pointer_t)hue->Data);
   TraceEOL();
 
   TraceFunctionExit(__func__);
@@ -751,12 +768,12 @@ static hash_value_type get_value_attack_nosuccess(dhtElement const *hue,
 {
   unsigned int const offset = slice_properties[si].u.d.offsetNoSucc;
   unsigned int const mask = slice_properties[si].u.d.maskNoSucc;
-  data_type const result = (mask & (data_type)hue->Data) >> offset;
+  data_type const result = (mask & (data_type)(uint_pointer_t)hue->Data) >> offset;
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",si);
   TraceValue("%08x ",mask);
   TraceValue("%p",(void *)&hue->Data);
-  TraceValue("%08x",(unsigned int)hue->Data);
+  TraceValue("%08x",(unsigned int)(uint_pointer_t)hue->Data);
   TraceEOL();
 
   TraceFunctionExit(__func__);
@@ -770,13 +787,13 @@ static hash_value_type get_value_help(dhtElement const *hue,
 {
   unsigned int const offset = slice_properties[si].u.h.offsetNoSucc;
   unsigned int const  mask = slice_properties[si].u.h.maskNoSucc;
-  data_type const result = (mask & (data_type)hue->Data) >> offset;
+  data_type const result = (mask & (data_type)(uint_pointer_t)hue->Data) >> offset;
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",si);
   TraceValue("%u",offset);
   TraceValue("0x%08x ",mask);
   TraceValue("%p ",(void *)&hue->Data);
-  TraceValue("0x%08x",(unsigned int)hue->Data);
+  TraceValue("0x%08x",(unsigned int)(uint_pointer_t)hue->Data);
   TraceEOL();
 
   TraceFunctionExit(__func__);

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -667,7 +667,7 @@ static void set_value_attack_nosuccess(dhtElement *hue,
   TraceValue("%u",offset);
   TraceValue("%08x ",mask);
   TraceValue("%p",(void *)&hue->Data);
-  TraceValue("pre:%08x ",(unsigned int)hue->Data);
+  TraceValue("pre:%08x ",(unsigned int)(uint_pointer_type)hue->Data);
   TraceValue("%08x",bits);
   TraceEOL();
   assert((bits&mask)==bits);
@@ -699,7 +699,7 @@ static void set_value_attack_success(dhtElement *hue,
   TraceValue("%u",offset);
   TraceValue("%08x ",mask);
   TraceValue("%p",(void *)&hue->Data);
-  TraceValue("pre:%08x ",(unsigned int)hue->Data);
+  TraceValue("pre:%08x ",(unsigned int)(uint_pointer_type)hue->Data);
   TraceValue("%08x",bits);
   TraceEOL();
   assert((bits&mask)==bits);
@@ -730,7 +730,7 @@ static void set_value_help(dhtElement *hue,
   TraceValue("%u",offset);
   TraceValue("0x%08x ",mask);
   TraceValue("%p ",(void *)&hue->Data);
-  TraceValue("pre:0x%08x ",(unsigned int)hue->data);
+  TraceValue("pre:0x%08x ",(unsigned int)(uint_pointer_type)hue->data);
   TraceValue("0x%08x",bits);
   TraceEOL();
   assert((bits&mask)==bits);
@@ -738,7 +738,7 @@ static void set_value_help(dhtElement *hue,
   tmp &= ~mask;
   tmp |= bits;
   hue->Data = (dhtConstValue)(uint_pointer_type)tmp;
-  TraceValue("post:0x%08x",(unsigned int)hue->Data);
+  TraceValue("post:0x%08x",(unsigned int)(uint_pointer_type)hue->Data);
   TraceEOL();
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();


### PR DESCRIPTION
This is my attempted resolution to Issue #316.&nbsp; It's imperfect as it requires an integral type large enough to store pointers to exist as well as int -> pointer -> int to preserve value, neither of which seem to be guaranteed by the standard.&nbsp; Nonetheless, I believe this should work everywhere that the code currently seems to.&nbsp; Moreover, all the operations should at least be _legal_, whereas treating the return value of `allocDHTelement` &mdash; which itself comes from `dhtEnterElement` &mdash; as a `hashElement_union_t *` when neither `allocDHTelement` nor `dhtEnterElement` make any use of that type (and the latter can't even _know_ of its existence) seems sketchy _at best_.

(_Ideally_ the keys and values of hashes would themselves be `union`s, allowing a multitude of types to be stored as needed.&nbsp; Implementing that seems _significantly_ harder [or at least more confusing].)