### PR TITLE
Add ALLOW_MEMORY_GROWTH to emcc toolchain

### DIFF
--- a/toolchains/emcc/make.incl
+++ b/toolchains/emcc/make.incl
@@ -14,7 +14,7 @@ include toolchains/gcc/make.incl
 CCHOST=emcc
 LDHOST=emcc
 CCTARGET=emcc
-LDTARGET=emcc -s EXPORTED_FUNCTIONS="['_main']" --memory-init-file 0 -s TOTAL_MEMORY=33554432 -s ABORTING_MALLOC=0
+LDTARGET=emcc -s EXPORTED_FUNCTIONS="['_main']" --memory-init-file 0 -s ALLOW_MEMORY_GROWTH=1 -s TOTAL_MEMORY=33554432 -s ABORTING_MALLOC=0
 EXE_SUFFIX=.js
 ARCHIVER=emar rv
 ARCHIVE_INDEXER=emranlib


### PR DESCRIPTION
By adding this option, the compiled package can then accept memory allocation greater than 32MB, which is quite important in practice.