### PR TITLE
Increase hashbuf_length

### DIFF
--- a/DHT/dhtbcmem.h
+++ b/DHT/dhtbcmem.h
@@ -16,7 +16,7 @@
  */
 
 typedef struct BCMemValue {
-	unsigned char	Leng;
+	unsigned short	Leng;
 	unsigned char	Data[1];
 } BCMemValue;
 

--- a/DHT/fxf.c
+++ b/DHT/fxf.c
@@ -102,9 +102,9 @@ typedef struct {
 
 /* The maximum size an fxfAlloc can handle */
 #if defined(SEGMENTED) || defined(__TURBOC__)
-#define fxfMAXSIZE  ((size_t)1024)
+#define fxfMAXSIZE  ((size_t)4096)
 #else
-#define fxfMAXSIZE  ((size_t)2048)  /* this is needed only when sizeof(void*)==8 */
+#define fxfMAXSIZE  ((size_t)8192)  /* this is needed only when sizeof(void*)==8 */
 #endif
 
 /* Different size of fxfMINSIZE for 32-/64/Bit compilation */

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -1261,7 +1261,7 @@ static void ProofEncode(stip_length_type min_length, stip_length_type validity_v
   bp = CommonEncode(bp,min_length,validity_value);
 
   assert(bp-hb->cmv.Data<=UCHAR_MAX);
-  hb->cmv.Leng = (unsigned char)(bp-hb->cmv.Data);
+  hb->cmv.Leng = (unsigned short)(bp-hb->cmv.Data);
 }
 
 static unsigned int TellCommonEncodePosLeng(unsigned int len,
@@ -1562,7 +1562,7 @@ static void LargeEncode(stip_length_type min_length,
   bp = CommonEncode(bp,min_length,validity_value);
 
   assert(bp-hb->cmv.Data<=UCHAR_MAX);
-  hb->cmv.Leng = (unsigned char)(bp-hb->cmv.Data);
+  hb->cmv.Leng = (unsigned short)(bp-hb->cmv.Data);
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -1626,7 +1626,7 @@ static void SmallEncode(stip_length_type min_length,
   bp = CommonEncode(bp,min_length,validity_value);
 
   assert(bp-hb->cmv.Data<=UCHAR_MAX);
-  hb->cmv.Leng = (unsigned char)(bp-hb->cmv.Data);
+  hb->cmv.Leng = (unsigned short)(bp-hb->cmv.Data);
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -1260,7 +1260,7 @@ static void ProofEncode(stip_length_type min_length, stip_length_type validity_v
   /* Now the rest of the party */
   bp = CommonEncode(bp,min_length,validity_value);
 
-  assert(bp-hb->cmv.Data<=UCHAR_MAX);
+  assert(bp-hb->cmv.Data<=2*UCHAR_MAX);
   hb->cmv.Leng = (unsigned short)(bp-hb->cmv.Data);
 }
 
@@ -1561,7 +1561,7 @@ static void LargeEncode(stip_length_type min_length,
   /* Now the rest of the party */
   bp = CommonEncode(bp,min_length,validity_value);
 
-  assert(bp-hb->cmv.Data<=UCHAR_MAX);
+  assert(bp-hb->cmv.Data<=2*UCHAR_MAX);
   hb->cmv.Leng = (unsigned short)(bp-hb->cmv.Data);
 
   TraceFunctionExit(__func__);
@@ -1625,7 +1625,7 @@ static void SmallEncode(stip_length_type min_length,
   /* Now the rest of the party */
   bp = CommonEncode(bp,min_length,validity_value);
 
-  assert(bp-hb->cmv.Data<=UCHAR_MAX);
+  assert(bp-hb->cmv.Data<=2*UCHAR_MAX);
   hb->cmv.Leng = (unsigned short)(bp-hb->cmv.Data);
 
   TraceFunctionExit(__func__);

--- a/optimisations/hash.h
+++ b/optimisations/hash.h
@@ -25,7 +25,7 @@ typedef unsigned char byte;
 
 enum
 {
-  hashbuf_length = 256
+  hashbuf_length = 512
 };
 
 typedef union


### PR DESCRIPTION
This PR is motivated by the following problem:
```
fors krbrqqqq/rbqsbrbq/qrbsqsbr/qqqrbsqb/qqqqqrbr/qqqqqqbS/brqqqqqq/Kbqqqqqq
stip #3
```
It has a solution `1.Nxg5!`, but in some environments (namely wasm and certain MacOS builds) it has been reproduced that Popeye failed to find the solution.

Deep inspection of the issue revealed that for positions such as this, they can easily be encoded to more than 256 bytes expected in the hash table. This PR doubles the size to 512 bytes, making sure that Popeye runs correctly no matter how ridiculous the position might seem.