### PR TITLE
Feature/fix issue416

### DIFF
--- a/REGRESSIONTESTS/zeitmax.out
+++ b/REGRESSIONTESTS/zeitmax.out
@@ -25,11 +25,11 @@
 
   1.Lg1-e3   2.g2-g1=S   3.Sg1-h3   4.Sh3-f2   5.Tg3-h3 0-0
   1.c2-c1=L   2.b2-b1=T   3.Tb1-b2   4.Lc1-h6   5.Tc5-g5 0-0-0
-  add_to_move_generation_stack:    41617229
-                     play_move:     8997914
- is_white_king_square_attacked:     2650582
- is_black_king_square_attacked:     8922012
-Partielle Loesung
+  add_to_move_generation_stack:    33228794
+                     play_move:     6884597
+ is_white_king_square_attacked:     1920255
+ is_black_king_square_attacked:     6810421
+Bearbeitung abgebrochen.
 
 
 
@@ -60,11 +60,11 @@ Partielle Loesung
   h#11                        1 + 3
           Beamtet h8 a3 a1
 
-  add_to_move_generation_stack:    14251298
-                     play_move:    13150642
+  add_to_move_generation_stack:    10058153
+                     play_move:     9230375
  is_white_king_square_attacked:           0
- is_black_king_square_attacked:    11750516
-Partielle Loesung
+ is_black_king_square_attacked:     8209377
+Bearbeitung abgebrochen.
 
 
 
@@ -95,18 +95,18 @@ NG24, 1. NG-ST, Problemkiste 109, 2/1997
 
 a) 
 
-  add_to_move_generation_stack:    19317576
-                     play_move:    19317576
- is_white_king_square_attacked:     4507652
- is_black_king_square_attacked:    19273456
+  add_to_move_generation_stack:    12120317
+                     play_move:    12120317
+ is_white_king_square_attacked:     2798585
+ is_black_king_square_attacked:    12088757
 
 b) wKc1-->b3  
 
-  add_to_move_generation_stack:    19219067
-                     play_move:    19219067
- is_white_king_square_attacked:     4503607
- is_black_king_square_attacked:    19185708
-Partielle Loesung
+  add_to_move_generation_stack:    12043746
+                     play_move:    12043746
+ is_white_king_square_attacked:     2763652
+ is_black_king_square_attacked:    12020954
+Bearbeitung abgebrochen.
 
 
 eigentlich:  ser-h=8/3
@@ -185,11 +185,11 @@ Motto: Viele Koeche verderben den Brei
   3  (Se1-d3 )
   4  (Se1-c2 )
   5  (Ke2-d1 )
-  add_to_move_generation_stack:    14180533
-                     play_move:     7690515
- is_white_king_square_attacked:      425185
- is_black_king_square_attacked:     7368777
-Partielle Loesung
+  add_to_move_generation_stack:     9024158
+                     play_move:     4839203
+ is_white_king_square_attacked:      243190
+ is_black_king_square_attacked:     4674580
+Bearbeitung abgebrochen.
 
 
 
@@ -220,12 +220,11 @@ Partielle Loesung
 
   1  (Sh1-g3 )
   2  (Sh1-f2 )
-  3  (c3-c2 )
-  add_to_move_generation_stack:    36540879
-                     play_move:    25014067
- is_white_king_square_attacked:     5211971
- is_black_king_square_attacked:    24998281
-Partielle Loesung
+  add_to_move_generation_stack:    21280387
+                     play_move:    14422892
+ is_white_king_square_attacked:     3110691
+ is_black_king_square_attacked:    14414839
+Bearbeitung abgebrochen.
 
 
 
@@ -254,11 +253,11 @@ Partielle Loesung
   #7                          5 + 2
               MarsCirce
 
-  add_to_move_generation_stack:    21573907
-                     play_move:     7902141
- is_white_king_square_attacked:      535927
- is_black_king_square_attacked:     7442195
-Partielle Loesung
+  add_to_move_generation_stack:    12321193
+                     play_move:     4468412
+ is_white_king_square_attacked:      293281
+ is_black_king_square_attacked:     4209876
+Bearbeitung abgebrochen.
 
 
 
@@ -288,11 +287,11 @@ Partielle Loesung
   =8                          3 + 1
               MarsCirce
 
-  add_to_move_generation_stack:    59855146
-                     play_move:    10066016
+  add_to_move_generation_stack:    35388383
+                     play_move:     5749584
  is_white_king_square_attacked:           0
- is_black_king_square_attacked:     9656214
-Partielle Loesung
+ is_black_king_square_attacked:     5538426
+Bearbeitung abgebrochen.
 
 
 
@@ -558,11 +557,11 @@ Loesung beendet.
   h=5                         2 + 4
              OhneSchach
 
-  add_to_move_generation_stack:   180708774
-                     play_move:    17086662
- is_white_king_square_attacked:    17025959
- is_black_king_square_attacked:    15491689
-Partielle Loesung
+  add_to_move_generation_stack:    89275187
+                     play_move:     9172731
+ is_white_king_square_attacked:     9153699
+ is_black_king_square_attacked:     8307841
+Bearbeitung abgebrochen.
 
 
 
@@ -592,11 +591,11 @@ Partielle Loesung
              OhneSchach
 
   1  (b2-b1=D )
-  add_to_move_generation_stack:   214644288
-                     play_move:    17881873
- is_white_king_square_attacked:    17753529
- is_black_king_square_attacked:    17254881
-Partielle Loesung
+  add_to_move_generation_stack:   102289194
+                     play_move:     8826080
+ is_white_king_square_attacked:     8783204
+ is_black_king_square_attacked:     8535857
+Bearbeitung abgebrochen.
 
 
 
@@ -627,11 +626,11 @@ Partielle Loesung
              OhneSchach
 
   1  (Ka1-b2 )
-  add_to_move_generation_stack:   148503300
-                     play_move:    16450480
- is_white_king_square_attacked:    16351465
- is_black_king_square_attacked:    14978354
-Partielle Loesung
+  add_to_move_generation_stack:    79386169
+                     play_move:     8859937
+ is_white_king_square_attacked:     8807646
+ is_black_king_square_attacked:     8039103
+Bearbeitung abgebrochen.
 
 
 
@@ -661,12 +660,11 @@ Partielle Loesung
                 Circe
              OhneSchach
 
-  1  (Kb1-c2 )
-  add_to_move_generation_stack:   160399692
-                     play_move:    15609911
- is_white_king_square_attacked:    15419242
- is_black_king_square_attacked:    14578618
-Partielle Loesung
+  add_to_move_generation_stack:    78383592
+                     play_move:     8559341
+ is_white_king_square_attacked:     8528556
+ is_black_king_square_attacked:     7873574
+Bearbeitung abgebrochen.
 
 
 
@@ -696,11 +694,11 @@ Partielle Loesung
              Ohneschlag
              OhneSchach
 
-  add_to_move_generation_stack:   140411969
-                     play_move:    16512630
- is_white_king_square_attacked:    16503657
- is_black_king_square_attacked:    15338415
-Partielle Loesung
+  add_to_move_generation_stack:    69411760
+                     play_move:     8229625
+ is_white_king_square_attacked:     8227007
+ is_black_king_square_attacked:     7667395
+Bearbeitung abgebrochen.
 
 
 
@@ -740,39 +738,28 @@ a)
   6  (Tc5-c2 )
   7  (Tc5-c3 )
   8  (Tc5-c4 + )
-  9  (Tc5-a5 )
- 10  (Tc5-b5 )
- 11  (Tc5-c8 )
- 12  (Tc5-c7 )
- 13  (Tc5-c6 )
- 14  (Tc5-h5 )
- 15  (Tc5-g5 )
-  add_to_move_generation_stack:     6439397
-                     play_move:     6360493
- is_white_king_square_attacked:       80696
- is_black_king_square_attacked:     6320336
+  add_to_move_generation_stack:     3995027
+                     play_move:     3946383
+ is_white_king_square_attacked:       48930
+ is_black_king_square_attacked:     3923868
 
 b) sKa7-->b1  
 
- 16  (Kb1-c2 )
- 17  (Kb1-a2 )
- 18  (Kb1-a1 )
- 19  (Kb1-b2 )
- 20  (Kb1*c1[+wSg1] )
- 21  (La3*c1[+wSg1] )
+  9  (Kb1-c2 )
+ 10  (Kb1-a2 )
+ 11  (Kb1-a1 )
+ 12  (Kb1-b2 )
+ 13  (Kb1*c1[+wSg1] )
+ 14  (La3*c1[+wSg1] )
   1.La3*c1[+wSg1] Kd4-c5   2.Tg2-g7 Sh7-g5   3.Tc5-c3 + Sb4*c6[+sTa8] #
- 22  (La3-b2 )
- 23  (La3-b4 )
- 24  (f3-f2 )
- 25  (Tc5*c1[+wSg1] )
- 26  (Tc5-c2 )
- 27  (Tc5-c3 )
- 28  (Tc5-c4 + )
- 29  (Tc5-a5 )
-  add_to_move_generation_stack:     6253961
-                     play_move:     5808833
- is_white_king_square_attacked:      282766
- is_black_king_square_attacked:     5774184
-Partielle Loesung
+ 15  (La3-b2 )
+ 16  (La3-b4 )
+ 17  (f3-f2 )
+ 18  (Tc5*c1[+wSg1] )
+  add_to_move_generation_stack:     4406399
+                     play_move:     4080475
+ is_white_king_square_attacked:      211035
+ is_black_king_square_attacked:     4057943
+Bearbeitung abgebrochen.
 
 

--- a/solving/incomplete.c
+++ b/solving/incomplete.c
@@ -35,7 +35,7 @@ solving_completeness_type problem_solving_completeness(slice_index si)
   TraceFunctionParamListEnd();
 
   assert(SLICE_TYPE(si)==STProblemSolvingIncomplete);
-  result = (SLICE_U(si).flag_handler.value ? solving_partial : solving_complete);
+  result = ((SLICE_U(si).value_handler.value == solving_complete) ? solving_complete : solving_partial);
 
   TraceFunctionExit(__func__);
   TraceFunctionResult("%u",result);

--- a/solving/incomplete.c
+++ b/solving/incomplete.c
@@ -35,7 +35,7 @@ solving_completeness_type problem_solving_completeness(slice_index si)
   TraceFunctionParamListEnd();
 
   assert(SLICE_TYPE(si)==STProblemSolvingIncomplete);
-  result = ((SLICE_U(si).value_handler.value == solving_complete) ? solving_complete : solving_partial);
+  result = (solving_completeness_type)SLICE_U(si).value_handler.value;
 
   TraceFunctionExit(__func__);
   TraceFunctionResult("%u",result);
@@ -81,7 +81,7 @@ void phase_solving_incomplete_solve(slice_index si)
   TraceFunctionParam("%u",si);
   TraceFunctionParamListEnd();
 
-  SLICE_U(si).flag_handler.value = solving_complete;
+  SLICE_U(si).value_handler.value = solving_complete;
 
   pipe_solve_delegate(si);
 
@@ -127,7 +127,7 @@ solving_completeness_type phase_solving_completeness(slice_index si)
   TraceFunctionParamListEnd();
 
   assert(SLICE_TYPE(si)==STPhaseSolvingIncomplete);
-  result = (SLICE_U(si).flag_handler.value ? solving_partial : solving_complete);
+  result = (solving_completeness_type)SLICE_U(si).value_handler.value;
 
   TraceFunctionExit(__func__);
   TraceFunctionResult("%u",result);


### PR DESCRIPTION
I think this is the simple fix to Issue #416.&nbsp; The problem is that this part of the code is generally writing to `Slice::u.value_handler.value` but is occasionally reading from (the corresponding) `Slice::u.flag_handler.value`.&nbsp; My guess is that `solving_completeness_type` used to only consist of the two values `solving_complete` and `solving_partial`.&nbsp; Eventually `solving_interrupted` was added, and this forced storing the value into the larger `Slice::u.value_type.value` field, the two-valued `Slice::u.flag_handler.value` no longer being sufficient.&nbsp; Unfortunately, this change wasn't properly propagated everywhere, and this PR completes that update.

Besides eliminating the undefined behavior, this PR (probably) makes it possible to reach the `solving_interrupted` `case` in `void output_plaintext_problem_writer_solve(slice_index si)` in [`output/plaintext/problem.c`](https://github.com/thomas-maeder/popeye/blob/develop/output/plaintext/problem.c).&nbsp; More generally, it ensures that `solving_interrupted` is properly passed through.&nbsp; The effects of accidentally replacing `solving_interrupted` with `solving_partial` (as currently happens on my system[s]) are unclear, but on big-endian systems we'd likely see `solving_interrupted` and `solving_partial` replaced with `solving_complete`.