### PR TITLE
Feature/fix issue417

### DIFF
--- a/conditions/mummer.c
+++ b/conditions/mummer.c
@@ -93,12 +93,11 @@ mummer_length_type minimummer_measure_length(void)
 /* Forget previous mummer activations and definition of length measurers */
 void mummer_reset_length_measurers(void)
 {
-  int s;
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  for (s=0; s<((sizeof mummer_measure_length)/(sizeof mummer_measure_length[0])); ++s)
-    mummer_measure_length[s] = NULL;
+  mummer_measure_length[White] = NULL;
+  mummer_measure_length[Black] = NULL;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -117,6 +116,7 @@ boolean mummer_set_length_measurer(Side side,
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
+  assert(side <= nr_sides);
   if (mummer_measure_length[side])
     result = false;
   else
@@ -224,6 +224,8 @@ void mummer_bookkeeper_solve(slice_index si)
   TraceFunctionParam("%u",si);
   TraceFunctionParamListEnd();
 
+  assert(SLICE_STARTER(si) < nr_sides);
+  assert(!!mummer_measure_length[SLICE_STARTER(si)]);
   current_length = (*mummer_measure_length[SLICE_STARTER(si)])();
   TraceValue("%u",current_length);
   TraceValue("%u",mum_length[parent_ply[nbply]]);
@@ -276,6 +278,7 @@ static void instrument_move_generator(slice_index si, stip_structure_traversal *
   TraceFunctionParam("%u",si);
   TraceFunctionParamListEnd();
 
+  assert(SLICE_STARTER(si) <= nr_sides);
   if (mummer_measure_length[SLICE_STARTER(si)])
   {
     if (state->ultra_capturing_king)
@@ -549,6 +552,8 @@ boolean ultra_mummer_validate_observation(slice_index si)
 
   conditional_pipe_solve_delegate(temporary_hack_ultra_mummer_length_measurer[side_observing]);
 
+  assert(side_observing < nr_sides);
+  assert(!!mummer_measure_length[side_observing]);
   result = (*mummer_measure_length[side_observing])()==mum_length[nbply];
 
   if (result)

--- a/conditions/mummer.c
+++ b/conditions/mummer.c
@@ -98,6 +98,7 @@ void mummer_reset_length_measurers(void)
 
   mummer_measure_length[White] = 0;
   mummer_measure_length[Black] = 0;
+  mummer_measure_length[no_side] = 0;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();

--- a/conditions/mummer.c
+++ b/conditions/mummer.c
@@ -98,7 +98,7 @@ void mummer_reset_length_measurers(void)
   TraceFunctionParamListEnd();
 
   for (s=0; s<((sizeof mummer_measure_length)/(sizeof mummer_measure_length[0])); ++s)
-    mummer_measure_length[s] = 0;
+    mummer_measure_length[s] = NULL;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -117,13 +117,13 @@ boolean mummer_set_length_measurer(Side side,
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  if (mummer_measure_length[side]==0)
+  if (mummer_measure_length[side])
+    result = false;
+  else
   {
     mummer_measure_length[side] = measurer;
     result = true;
   }
-  else
-    result = false;
 
   TraceFunctionExit(__func__);
   TraceFunctionResult("%u",result);

--- a/conditions/mummer.c
+++ b/conditions/mummer.c
@@ -31,7 +31,7 @@ static mummer_length_type mum_length[maxply+1];
 /* index of last move with mum length */
 static numecoup last_candidate[maxply+1];
 
-static mummer_length_measurer_type mummer_measure_length[nr_sides];
+static mummer_length_measurer_type mummer_measure_length[nr_sides+1];
 
 mummer_strictness_type mummer_strictness[nr_sides];
 

--- a/conditions/mummer.c
+++ b/conditions/mummer.c
@@ -93,12 +93,12 @@ mummer_length_type minimummer_measure_length(void)
 /* Forget previous mummer activations and definition of length measurers */
 void mummer_reset_length_measurers(void)
 {
+  int s;
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  mummer_measure_length[White] = 0;
-  mummer_measure_length[Black] = 0;
-  mummer_measure_length[no_side] = 0;
+  for (s=0; s<((sizeof mummer_measure_length)/(sizeof mummer_measure_length[0])); ++s)
+    mummer_measure_length[s] = 0;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();

--- a/conditions/mummer.c
+++ b/conditions/mummer.c
@@ -93,11 +93,12 @@ mummer_length_type minimummer_measure_length(void)
 /* Forget previous mummer activations and definition of length measurers */
 void mummer_reset_length_measurers(void)
 {
+  int s;
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  mummer_measure_length[White] = NULL;
-  mummer_measure_length[Black] = NULL;
+  for (s = 0; s < nr_sides; ++s)
+    mummer_measure_length[s] = NULL;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();


### PR DESCRIPTION
This is my simple attempt at fixing Issue #417.&nbsp; The problem is that we're reaching line 278 of [`conditions/mummer.c`](https://github.com/thomas-maeder/popeye/blob/develop/conditions/mummer.c) with `SLICE_STARTER(si) == no_side` and there's no corresponding entry in `mummer_measure_length`.&nbsp; This fix adds such an entry and sets it to `NULL`, which is the only sensible default for an unspecified function pointer.&nbsp; This clears the undefined behavior (and ensures we skip lines 280-303) and is plausibly correct, but there remains an alternative.&nbsp; _Perhaps_ in fact the bug is higher up in whatever is _causing_ us to reach that point `SLICE_STARTER(si) == no_side`.&nbsp; If so then that would still need to be fixed, but even if that's the case adding this entry to `mummer_measure_length` can't hurt anything.