### PR TITLE
Feature/fix zzz accesses

### DIFF
--- a/conditions/wormhole.c
+++ b/conditions/wormhole.c
@@ -306,18 +306,11 @@ void wormhole_initialse_solving(slice_index si)
   nr_wormholes = 0;
 
   {
-    square s;
-    int j;
+    square s, j;
     for (s = square_a1; s<=square_a8; s += (square_a2 - square_a1))
-      for (j = 0; j<nr_files_on_board; ++j)
-      {
-        square cur_square = (square)(s + j * (square_b1 - square_a1));
-        if (TSTFLAG(sq_spec(cur_square),Wormhole))
-        {
-          wormhole_positions[nr_wormholes] = cur_square;
-          ++nr_wormholes;
-        }
-      }
+      for (j = (square_a1 - square_a1); j<=(square_h1 - square_a1); j += (square_b1 - square_a1))
+        if (TSTFLAG(sq_spec(s + j),Wormhole))
+          wormhole_positions[nr_wormholes++] = s + j;
   }
 
   {

--- a/conditions/wormhole.c
+++ b/conditions/wormhole.c
@@ -307,12 +307,14 @@ void wormhole_initialse_solving(slice_index si)
 
   {
     square s;
-    for (s = square_a1; s<=square_h8; ++s)
-      if (TSTFLAG(sq_spec(s),Wormhole))
-      {
-        wormhole_positions[nr_wormholes] = s;
-        ++nr_wormholes;
-      }
+    int j;
+    for (s = square_a1; s<=square_a8; s += (square_a2 - square_a1))
+      for (j = 0; j<nr_files_on_board; ++j)
+        if (TSTFLAG(sq_spec(s+j),Wormhole))
+        {
+          wormhole_positions[nr_wormholes] = (square)(s+j);
+          ++nr_wormholes;
+        }
   }
 
   {

--- a/conditions/wormhole.c
+++ b/conditions/wormhole.c
@@ -310,11 +310,14 @@ void wormhole_initialse_solving(slice_index si)
     int j;
     for (s = square_a1; s<=square_a8; s += (square_a2 - square_a1))
       for (j = 0; j<nr_files_on_board; ++j)
-        if (TSTFLAG(sq_spec(s+j),Wormhole))
+      {
+        square cur_square = (square)(s + j * (square_b1 - square_a1));
+        if (TSTFLAG(sq_spec(cur_square),Wormhole))
         {
-          wormhole_positions[nr_wormholes] = (square)(s+j);
+          wormhole_positions[nr_wormholes] = cur_square;
           ++nr_wormholes;
         }
+      }
   }
 
   {

--- a/output/plaintext/condition.c
+++ b/output/plaintext/condition.c
@@ -51,12 +51,12 @@
 
 static unsigned int WriteWalks(char *pos, piece_walk_type const walks[], unsigned int nr_walks)
 {
-  unsigned int i;
+  unsigned int walk_index;
   unsigned int result = 0;
 
-  for (i = 0; i!=nr_walks; ++i)
+  for (walk_index = 0; walk_index!=nr_walks; ++walk_index)
   {
-    piece_walk_type const walk = walks[i];
+    piece_walk_type const walk = walks[walk_index];
 
     if (walk<Hunter0 || walk>= (Hunter0 + max_nr_hunter_walks))
     {

--- a/output/plaintext/condition.c
+++ b/output/plaintext/condition.c
@@ -647,53 +647,58 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
         case magicsquare:
         {
           square i;
+          int j;
           if (magic_square_type==ConditionType2)
             written += append_to_CondLine(&CondLine,written, " %s", ConditionNumberedVariantTypeTab[ConditionType2]);
 
-          for (i= square_a1; i <= square_h8; i++) {
-            if (TSTFLAG(sq_spec(i), MagicSq))
-              written += append_to_CondLine_square(&CondLine,written,i);
-          }
+          for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
+            for (j= 0; j<nr_files_on_board; ++j)
+              if (TSTFLAG(sq_spec(i+j), MagicSq))
+                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
           break;
         }
 
         case whforsqu:
         case whconforsqu:
         {
-          square  i;
-          for (i= square_a1; i <= square_h8; i++) {
-            if (TSTFLAG(sq_spec(i), WhForcedSq))
-              written += append_to_CondLine_square(&CondLine,written,i);
-          }
+          square i;
+          int j;
+          for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
+            for (j= 0; j<nr_files_on_board; ++j)
+              if (TSTFLAG(sq_spec(i+j), WhForcedSq))
+                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
           break;
         }
         case blforsqu:
         case blconforsqu:
         {
-          square  i;
-          for (i= square_a1; i <= square_h8; i++) {
-            if (TSTFLAG(sq_spec(i), BlForcedSq))
-              written += append_to_CondLine_square(&CondLine,written,i);
-          }
+          square i;
+          int j;
+          for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
+            for (j= 0; j<nr_files_on_board; ++j)
+              if (TSTFLAG(sq_spec(i+j), BlForcedSq))
+                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
           break;
         }
 
         case whprom_sq:
         {
-          square  i;
-          for (i= square_a1; i <= square_h8; i++) {
-            if (TSTFLAG(sq_spec(i), WhPromSq))
-              written += append_to_CondLine_square(&CondLine,written,i);
-          }
+          square i;
+          int j;
+          for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
+            for (j= 0; j<nr_files_on_board; ++j)
+              if (TSTFLAG(sq_spec(i+j), WhPromSq))
+                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
           break;
         }
         case blprom_sq:
         {
-          square  i;
-          for (i= square_a1; i <= square_h8; i++) {
-            if (TSTFLAG(sq_spec(i), BlPromSq))
-              written += append_to_CondLine_square(&CondLine,written,i);
-          }
+          square i;
+          int j;
+          for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
+            for (j= 0; j<nr_files_on_board; ++j)
+              if (TSTFLAG(sq_spec(i+j), BlPromSq))
+                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
           break;
         }
 
@@ -707,9 +712,11 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
         case wormholes:
         {
           square i;
-          for (i = square_a1; i<=square_h8; ++i)
-            if (TSTFLAG(sq_spec(i),Wormhole))
-              written += append_to_CondLine_square(&CondLine,written,i);
+          int j;
+          for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
+            for (j= 0; j<nr_files_on_board; ++j)
+              if (TSTFLAG(sq_spec(i+j),Wormhole))
+                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
           break;
         }
 

--- a/output/plaintext/condition.c
+++ b/output/plaintext/condition.c
@@ -653,8 +653,11 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
 
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
             for (j= 0; j<nr_files_on_board; ++j)
-              if (TSTFLAG(sq_spec(i+j), MagicSq))
-                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
+            {
+              square cur_square= (square)(i+j*(square_b1-square_a1));
+              if (TSTFLAG(sq_spec(cur_square), MagicSq))
+                written += append_to_CondLine_square(&CondLine,written,cur_square);
+            }
           break;
         }
 
@@ -665,8 +668,11 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
           int j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
             for (j= 0; j<nr_files_on_board; ++j)
-              if (TSTFLAG(sq_spec(i+j), WhForcedSq))
-                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
+            {
+              square cur_square= (square)(i+j*(square_b1-square_a1));
+              if (TSTFLAG(sq_spec(cur_square), WhForcedSq))
+                written += append_to_CondLine_square(&CondLine,written,cur_square);
+            }
           break;
         }
         case blforsqu:
@@ -676,8 +682,11 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
           int j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
             for (j= 0; j<nr_files_on_board; ++j)
-              if (TSTFLAG(sq_spec(i+j), BlForcedSq))
-                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
+            {
+              square cur_square= (square)(i+j*(square_b1-square_a1));
+              if (TSTFLAG(sq_spec(cur_square), BlForcedSq))
+                written += append_to_CondLine_square(&CondLine,written,cur_square);
+            }
           break;
         }
 
@@ -687,8 +696,11 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
           int j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
             for (j= 0; j<nr_files_on_board; ++j)
-              if (TSTFLAG(sq_spec(i+j), WhPromSq))
-                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
+            {
+              square cur_square= (square)(i+j*(square_b1-square_a1));
+              if (TSTFLAG(sq_spec(cur_square), WhPromSq))
+                written += append_to_CondLine_square(&CondLine,written,cur_square);
+            }
           break;
         }
         case blprom_sq:
@@ -697,8 +709,11 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
           int j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
             for (j= 0; j<nr_files_on_board; ++j)
-              if (TSTFLAG(sq_spec(i+j), BlPromSq))
-                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
+            {
+              square cur_square= (square)(i+j*(square_b1-square_a1));
+              if (TSTFLAG(sq_spec(cur_square), BlPromSq))
+                written += append_to_CondLine_square(&CondLine,written,cur_square);
+            }
           break;
         }
 
@@ -715,8 +730,11 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
           int j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
             for (j= 0; j<nr_files_on_board; ++j)
-              if (TSTFLAG(sq_spec(i+j),Wormhole))
-                written += append_to_CondLine_square(&CondLine,written,(square)(i+j));
+            {
+              square cur_square= (square)(i+j*(square_b1-square_a1));
+              if (TSTFLAG(sq_spec(cur_square),Wormhole))
+                written += append_to_CondLine_square(&CondLine,written,cur_square);
+            }
           break;
         }
 

--- a/output/plaintext/condition.c
+++ b/output/plaintext/condition.c
@@ -646,74 +646,54 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
 
         case magicsquare:
         {
-          square i;
-          int j;
+          square i, j;
           if (magic_square_type==ConditionType2)
             written += append_to_CondLine(&CondLine,written, " %s", ConditionNumberedVariantTypeTab[ConditionType2]);
 
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
-            for (j= 0; j<nr_files_on_board; ++j)
-            {
-              square cur_square= (square)(i+j*(square_b1-square_a1));
-              if (TSTFLAG(sq_spec(cur_square), MagicSq))
-                written += append_to_CondLine_square(&CondLine,written,cur_square);
-            }
+            for (j= (square_a1-square_a1); j<=(square_h1-square_a1); j+= (square_b1-square_a1))
+              if (TSTFLAG(sq_spec(i+j), MagicSq))
+                written += append_to_CondLine_square(&CondLine,written,i+j);
           break;
         }
 
         case whforsqu:
         case whconforsqu:
         {
-          square i;
-          int j;
+          square i, j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
-            for (j= 0; j<nr_files_on_board; ++j)
-            {
-              square cur_square= (square)(i+j*(square_b1-square_a1));
-              if (TSTFLAG(sq_spec(cur_square), WhForcedSq))
-                written += append_to_CondLine_square(&CondLine,written,cur_square);
-            }
+            for (j= (square_a1-square_a1); j<=(square_h1-square_a1); j+= (square_b1-square_a1))
+              if (TSTFLAG(sq_spec(i+j), WhForcedSq))
+                written += append_to_CondLine_square(&CondLine,written,i+j);
           break;
         }
         case blforsqu:
         case blconforsqu:
         {
-          square i;
-          int j;
+          square i, j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
-            for (j= 0; j<nr_files_on_board; ++j)
-            {
-              square cur_square= (square)(i+j*(square_b1-square_a1));
-              if (TSTFLAG(sq_spec(cur_square), BlForcedSq))
-                written += append_to_CondLine_square(&CondLine,written,cur_square);
-            }
+            for (j= (square_a1-square_a1); j<=(square_h1-square_a1); j+= (square_b1-square_a1))
+              if (TSTFLAG(sq_spec(i+j), BlForcedSq))
+                written += append_to_CondLine_square(&CondLine,written,i+j);
           break;
         }
 
         case whprom_sq:
         {
-          square i;
-          int j;
+          square i, j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
-            for (j= 0; j<nr_files_on_board; ++j)
-            {
-              square cur_square= (square)(i+j*(square_b1-square_a1));
-              if (TSTFLAG(sq_spec(cur_square), WhPromSq))
-                written += append_to_CondLine_square(&CondLine,written,cur_square);
-            }
+            for (j= (square_a1-square_a1); j<=(square_h1-square_a1); j+= (square_b1-square_a1))
+              if (TSTFLAG(sq_spec(i+j), WhPromSq))
+                written += append_to_CondLine_square(&CondLine,written,i+j);
           break;
         }
         case blprom_sq:
         {
-          square i;
-          int j;
+          square i, j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
-            for (j= 0; j<nr_files_on_board; ++j)
-            {
-              square cur_square= (square)(i+j*(square_b1-square_a1));
-              if (TSTFLAG(sq_spec(cur_square), BlPromSq))
-                written += append_to_CondLine_square(&CondLine,written,cur_square);
-            }
+            for (j= (square_a1-square_a1); j<=(square_h1-square_a1); j+= (square_b1-square_a1))
+              if (TSTFLAG(sq_spec(i+j), BlPromSq))
+                written += append_to_CondLine_square(&CondLine,written,i+j);
           break;
         }
 
@@ -726,15 +706,11 @@ void WriteConditions(FILE *file, condition_writer_type WriteCondition)
 
         case wormholes:
         {
-          square i;
-          int j;
+          square i, j;
           for (i= square_a1; i<=square_a8; i+= (square_a2-square_a1))
-            for (j= 0; j<nr_files_on_board; ++j)
-            {
-              square cur_square= (square)(i+j*(square_b1-square_a1));
-              if (TSTFLAG(sq_spec(cur_square),Wormhole))
-                written += append_to_CondLine_square(&CondLine,written,cur_square);
-            }
+            for (j= (square_a1-square_a1); j<=(square_h1-square_a1); j+= (square_b1-square_a1))
+              if (TSTFLAG(sq_spec(i+j),Wormhole))
+                written += append_to_CondLine_square(&CondLine,written,i+j);
           break;
         }
 

--- a/position/board.c
+++ b/position/board.c
@@ -80,7 +80,7 @@ square const boardnum[65] = {
   /* eighth  rank */      368, 369, 370, 371, 372, 373, 374, square_h8,
   /* end marker   */    0};
 
-SquareFlags zzzan[(one_row + 1) + (square_h8 - square_a1 + 1) + (one_row + 1)];
+SquareFlags zzzan[(onerow + 1) + (square_h8 - square_a1 + 1) + (onerow + 1)];
 
 int zzzao[square_h8 - square_a1 + 1];
 

--- a/position/board.c
+++ b/position/board.c
@@ -84,6 +84,19 @@ SquareFlags zzzan[(onerow + 1) + (square_h8 - square_a1 + 1) + (onerow + 1)];
 
 int zzzao[square_h8 - square_a1 + 1];
 
+int get_zzzan_index(square const s)
+{
+#ifndef NDEBUG
+  int col;
+  assert((s >= (square_a1 - 1 - onerow)) &&
+         (s <= (square_h8 + 1 + onerow)));
+  col = (s % onerow);
+  assert((col >= (left_file - 1)) &&
+         (col <= (right_file + 1)));
+#endif
+  return (s - (square_a1 - (onerow + 1)));
+}
+
 /* Calculate a square transformation
  * @param sq square to be reflected
  * @param transformation transformation to be performed

--- a/position/board.c
+++ b/position/board.c
@@ -80,7 +80,7 @@ square const boardnum[65] = {
   /* eighth  rank */      368, 369, 370, 371, 372, 373, 374, square_h8,
   /* end marker   */    0};
 
-SquareFlags zzzan[square_h8 - square_a1 + 1];
+SquareFlags zzzan[(one_row + 1) + (square_h8 - square_a1 + 1) + (one_row + 1)];
 
 int zzzao[square_h8 - square_a1 + 1];
 

--- a/position/board.h
+++ b/position/board.h
@@ -225,7 +225,7 @@ enum
   max_castling = queenside_castling
 };
 
-extern SquareFlags zzzan[(onerow + 1) + (square_h8 - square_a1 + 1) + (onerow + 1)]; // for this array we need slack rows above and below
+extern SquareFlags zzzan[(onerow + 1) + (square_h8 - square_a1 + 1) + (onerow + 1)]; // for this array we need slack entries all around the board
 #define sq_spec(n)      (zzzan[(n) - (square_a1 - (onerow + 1))])
 
 extern int         zzzao[square_h8 - square_a1 + 1];

--- a/position/board.h
+++ b/position/board.h
@@ -225,8 +225,8 @@ enum
   max_castling = queenside_castling
 };
 
-extern SquareFlags zzzan[(one_row + 1) + (square_h8 - square_a1 + 1) + (one_row + 1)]; // for this array we need slack rows above and below
-#define sq_spec(n)      (zzzan[(n) - (square_a1 - (one_row + 1))])
+extern SquareFlags zzzan[(onerow + 1) + (square_h8 - square_a1 + 1) + (onerow + 1)]; // for this array we need slack rows above and below
+#define sq_spec(n)      (zzzan[(n) - (square_a1 - (onerow + 1))])
 
 extern int         zzzao[square_h8 - square_a1 + 1];
 #define sq_num(n)       (zzzao[(n) - square_a1])

--- a/position/board.h
+++ b/position/board.h
@@ -226,10 +226,11 @@ enum
 };
 
 extern SquareFlags zzzan[(onerow + 1) + (square_h8 - square_a1 + 1) + (onerow + 1)]; /* for this array we need slack entries all around the board */
-#define sq_spec(n)      (zzzan[(n) - (square_a1 - (onerow + 1))])
+#define sq_spec(n)      zzzan[get_zzzan_index(n)]
+int get_zzzan_index(square s);
 
 extern int         zzzao[square_h8 - square_a1 + 1];
-#define sq_num(n)       (zzzao[(n) - square_a1])
+#define sq_num(n)       zzzao[(n) - square_a1]
 
 #define NoEdge(i)       TSTFLAG(sq_spec(i), NoEdgeSq)
 #define SquareCol(i)    TSTFLAG(sq_spec(i), SqColor)

--- a/position/board.h
+++ b/position/board.h
@@ -225,8 +225,8 @@ enum
   max_castling = queenside_castling
 };
 
-extern SquareFlags zzzan[square_h8 - square_a1 + 1];
-#define sq_spec(n)      (zzzan[(n) - square_a1])
+extern SquareFlags zzzan[(one_row + 1) + (square_h8 - square_a1 + 1) + (one_row + 1)]; // for this array we need slack rows above and below
+#define sq_spec(n)      (zzzan[(n) - (square_a1 - one_row - 1)])
 
 extern int         zzzao[square_h8 - square_a1 + 1];
 #define sq_num(n)       (zzzao[(n) - square_a1])

--- a/position/board.h
+++ b/position/board.h
@@ -225,7 +225,7 @@ enum
   max_castling = queenside_castling
 };
 
-extern SquareFlags zzzan[(onerow + 1) + (square_h8 - square_a1 + 1) + (onerow + 1)]; // for this array we need slack entries all around the board
+extern SquareFlags zzzan[(onerow + 1) + (square_h8 - square_a1 + 1) + (onerow + 1)]; /* for this array we need slack entries all around the board */
 #define sq_spec(n)      (zzzan[(n) - (square_a1 - (onerow + 1))])
 
 extern int         zzzao[square_h8 - square_a1 + 1];

--- a/position/board.h
+++ b/position/board.h
@@ -226,7 +226,7 @@ enum
 };
 
 extern SquareFlags zzzan[(one_row + 1) + (square_h8 - square_a1 + 1) + (one_row + 1)]; // for this array we need slack rows above and below
-#define sq_spec(n)      (zzzan[(n) - (square_a1 - one_row - 1)])
+#define sq_spec(n)      (zzzan[(n) - (square_a1 - (one_row + 1))])
 
 extern int         zzzao[square_h8 - square_a1 + 1];
 #define sq_num(n)       (zzzao[(n) - square_a1])


### PR DESCRIPTION
This is my attempt at fixing Issues #413, #414, and #419.  In each of these cases we're assessing squares that are just one entry outside of the board, so this update ensures that `zzzan` has the relevant entries.  While I was working on this, I also updated the straight "loops over the entire board" to _not_ waste time going over the slack entries.