### PR TITLE
Feature/fix issue418

### DIFF
--- a/conditions/dister.c
+++ b/conditions/dister.c
@@ -63,7 +63,7 @@ mummer_length_type maxdister_measure_length(void)
   if (dister_square[0]==initsquare || dister_square[1]==initsquare)
     result = 0;
   else
-    result = move_diff_code[abs(dister_square[0]-dister_square[1])];
+    result = squared_distance_between_squares(dister_square[0],dister_square[1]);
 
   TraceFunctionExit(__func__);
   TraceFunctionResult("%u",result);
@@ -123,7 +123,7 @@ mummer_length_type mindister_measure_length(void)
   if (dister_square[0]==initsquare || dister_square[1]==initsquare)
     result = 0;
   else
-    result = 1000-move_diff_code[abs(dister_square[0]-dister_square[1])];
+    result = 1000-squared_distance_between_squares(dister_square[0],dister_square[1]);
 
   TraceFunctionExit(__func__);
   TraceFunctionResult("%u",result);

--- a/conditions/mummer.c
+++ b/conditions/mummer.c
@@ -59,7 +59,7 @@ mummer_length_type maximummer_measure_length(void)
       return 25;
 
     case offset_platzwechsel_rochade:
-      return 2 * move_diff_code[abs(sq_arrival-sq_departure)];
+      return 2 * squared_distance_between_squares(sq_arrival,sq_departure);
 
     default:
       switch (get_walk_of_piece_on_square(sq_departure))
@@ -72,10 +72,10 @@ mummer_length_type maximummer_measure_length(void)
 
         default:
           if (sq_capture>offset_platzwechsel_rochade)
-            return (move_diff_code[abs(sq_arrival-sq_departure)]) +
-              (move_diff_code[abs((sq_capture-maxsquare)-(sq_departure+sq_arrival)/2)]);
+            return squared_distance_between_squares(sq_arrival,sq_departure) +
+              squared_distance_between_squares((sq_capture-maxsquare),(sq_departure+sq_arrival)/2);
           else
-           return (move_diff_code[abs(sq_arrival-sq_departure)]);
+           return squared_distance_between_squares(sq_arrival,sq_departure);
       }
       break;
   }

--- a/optimisations/intelligent/count_nr_of_moves.c
+++ b/optimisations/intelligent/count_nr_of_moves.c
@@ -568,7 +568,7 @@ static unsigned int count_nr_of_moves_same_piece_same_square_checking(piece_walk
 
      default:
        /* it's a rider */
-       if (move_diff_code[abs(being_solved.king_square[Black]-to_square)]<3)
+       if (squared_distance_between_squares(being_solved.king_square[Black],to_square)<3)
          result = 2;
        else
          result = 0;

--- a/optimisations/intelligent/guard_flights.c
+++ b/optimisations/intelligent/guard_flights.c
@@ -34,7 +34,7 @@ static void init_guard_dirs_rider(piece_walk_type guarder,
                                   numvec dir)
 {
   square const start = flight+dir;
-  if (move_diff_code[abs(being_solved.king_square[Black]-start)]<=2)
+  if (squared_distance_between_squares(being_solved.king_square[Black],start)<=2)
   {
     /* start is a flight, too.
      * GuardDir will be initialised from start in this dir */
@@ -208,7 +208,7 @@ void init_guard_dirs(square black_king_pos)
  */
 static boolean white_king_guards_flight(square from)
 {
-  move_diff_type const diff = move_diff_code[abs(being_solved.king_square[Black]-from)];
+  move_diff_type const diff = squared_distance_between_squares(being_solved.king_square[Black],from);
   boolean const result = diff>3 && diff<=8;
 
   TraceFunctionEntry(__func__);
@@ -245,7 +245,7 @@ static void remember_to_keep_guard_line_open(square from, square to,
   /* the guard line only needs to be kept open up to the flight closest to
    * from; e.g. reset to to c1 with from:a1 to:e1 being_solved.king_square[Black]:d2
    */
-  for (s = to-dir; s!=from && move_diff_code[abs(being_solved.king_square[Black]-s)]<=2; s -= dir)
+  for (s = to-dir; s!=from && squared_distance_between_squares(being_solved.king_square[Black],s)<=2; s -= dir)
     to = s;
 
   remember_to_keep_rider_line_open(from,to,dir,delta);
@@ -476,7 +476,7 @@ static void promoted_queen(slice_index si, square guard_from)
   TraceSquare(guard_from);
   TraceFunctionParamListEnd();
 
-  switch (move_diff_code[abs(being_solved.king_square[Black]-guard_from)])
+  switch (squared_distance_between_squares(being_solved.king_square[Black],guard_from))
   {
     case 1+0: /* e.g. Ka2 Qb2 */
     case 1+1: /* e.g. Ka2 Qb3 */
@@ -529,7 +529,7 @@ static void promoted_rook(slice_index si, square guard_from)
   TraceSquare(guard_from);
   TraceFunctionParamListEnd();
 
-  switch (move_diff_code[abs(being_solved.king_square[Black]-guard_from)])
+  switch (squared_distance_between_squares(being_solved.king_square[Black],guard_from))
   {
     case 1+0: /* e.g. Ka2 Rb2 */
       /* uninterceptable check */
@@ -566,7 +566,7 @@ static void promoted_rook(slice_index si, square guard_from)
  */
 static void promoted_bishop(slice_index si, square guard_from)
 {
-  move_diff_type const diff = move_diff_code[abs(being_solved.king_square[Black]-guard_from)];
+  move_diff_type const diff = squared_distance_between_squares(being_solved.king_square[Black],guard_from);
 
   TraceFunctionEntry(__func__);
   TraceSquare(guard_from);
@@ -671,7 +671,7 @@ static void queen(slice_index si, square guard_from)
   TraceSquare(guard_from);
   TraceFunctionParamListEnd();
 
-  switch (move_diff_code[abs(being_solved.king_square[Black]-guard_from)])
+  switch (squared_distance_between_squares(being_solved.king_square[Black],guard_from))
   {
     case 1+0: /* e.g. Ka2 Qb2 */
     case 1+1: /* e.g. Ka2 Qb3 */
@@ -727,7 +727,7 @@ static void rook(slice_index si, square guard_from)
   TraceSquare(guard_from);
   TraceFunctionParamListEnd();
 
-  switch (move_diff_code[abs(being_solved.king_square[Black]-guard_from)])
+  switch (squared_distance_between_squares(being_solved.king_square[Black],guard_from))
   {
     case 1+0: /* e.g. Ka2 Rb2 */
       /* uninterceptable check */
@@ -766,7 +766,7 @@ static void rook(slice_index si, square guard_from)
  */
 static void bishop(slice_index si, square guard_from)
 {
-  move_diff_type const diff = move_diff_code[abs(being_solved.king_square[Black]-guard_from)];
+  move_diff_type const diff = squared_distance_between_squares(being_solved.king_square[Black],guard_from);
 
   TraceFunctionEntry(__func__);
   TraceSquare(guard_from);

--- a/optimisations/intelligent/place_white_king.c
+++ b/optimisations/intelligent/place_white_king.c
@@ -80,7 +80,7 @@ static boolean guards_from(square white_king_square)
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  result = move_diff_code[abs(white_king_square-being_solved.king_square[Black])]<9;
+  result = squared_distance_between_squares(white_king_square,being_solved.king_square[Black])<9;
 
   TraceFunctionExit(__func__);
   TraceFunctionResult("%u",result);

--- a/optimisations/orthodox_mating_moves/king_contact_move_generator.c
+++ b/optimisations/orthodox_mating_moves/king_contact_move_generator.c
@@ -64,7 +64,7 @@ void orthodox_mating_king_contact_generator_solve(slice_index si)
     for (k = vec_queen_start; k<=vec_queen_end; k++)
     {
       curr_generation->arrival = curr_generation->departure+vec[k];
-      if (move_diff_code[abs(sq_mated_king-curr_generation->arrival)]<=1+1)
+      if (squared_distance_between_squares(sq_mated_king,curr_generation->arrival)<=1+1)
       {
         if (is_square_empty(curr_generation->arrival))
             push_move_no_capture();

--- a/optimisations/orthodox_mating_moves/orthodox_mating_move_generator.c
+++ b/optimisations/orthodox_mating_moves/orthodox_mating_move_generator.c
@@ -205,7 +205,7 @@ static void king_nonneutral(square sq_king, Side side)
       if (abs(dir)!=abs_dir_battery)
       {
         curr_generation->arrival = curr_generation->departure+dir;
-        if (move_diff_code[abs(sq_king-curr_generation->arrival)]>1+1)
+        if (squared_distance_between_squares(sq_king,curr_generation->arrival)>1+1)
         {
           if (is_square_empty(curr_generation->arrival))
             push_move_no_capture();
@@ -249,12 +249,12 @@ static void knight(square sq_king, Side side)
 
   {
     numvec const abs_dir_battery = detect_battery(sq_king,side);
-    numvec vec_to_king = abs(sq_king-sq_departure);
+    move_diff_type const dist_to_king = squared_distance_between_squares(sq_king,sq_departure);
 
     if (abs_dir_battery!=0
         || (SquareCol(sq_departure)==SquareCol(sq_king)
-            && move_diff_code[vec_to_king]<=move_diff_code[square_a3-square_e1]
-            && move_diff_code[vec_to_king]!=move_diff_code[square_a3-square_c1]))
+            && dist_to_king<=squared_distance_between_squares(square_a3,square_e1)
+            && dist_to_king!=squared_distance_between_squares(square_a3,square_c1)))
     {
       vec_index_type vec_index;
       for (vec_index = vec_knight_start; vec_index<=vec_knight_end; ++vec_index)
@@ -399,14 +399,14 @@ static void simple_rider_indirectly_approach_king(square sq_king,
                                                   piece_walk_type rider_walk)
 {
   square const sq_departure = curr_generation->departure;
-  move_diff_type const OriginalDistance = move_diff_code[abs(sq_departure-sq_king)];
+  move_diff_type const OriginalDistance = squared_distance_between_squares(sq_departure,sq_king);
   vec_index_type vec_index;
   for (vec_index = index_start; vec_index<=index_end; ++vec_index)
   {
     numvec const dir = vec[vec_index];
     curr_generation->arrival = sq_departure+dir;
     if (!is_square_blocked(curr_generation->arrival)
-        && move_diff_code[abs(curr_generation->arrival-sq_king)]<OriginalDistance)
+        && squared_distance_between_squares(curr_generation->arrival,sq_king)<OriginalDistance)
     {
       /* The rider must move closer to the king! */
       numvec dir_to_king = CheckDir(rider_walk)[sq_king-curr_generation->arrival];

--- a/pieces/attributes/total_invisible.c
+++ b/pieces/attributes/total_invisible.c
@@ -1,7 +1,6 @@
 #include "pieces/attributes/total_invisible.h"
 #include "pieces/walks/classification.h"
 #include "position/position.h"
-#include "position/move_diff_code.h"
 #include "position/effects/piece_readdition.h"
 #include "position/effects/piece_movement.h"
 #include "position/effects/null_move.h"

--- a/position/move_diff_code.c
+++ b/position/move_diff_code.c
@@ -1,8 +1,10 @@
 #include "position/move_diff_code.h"
+#include "position/board.h"
 
+#include <stdlib.h>
 #include <limits.h>
 
-move_diff_type const move_diff_code[square_h8 - square_a1 + 1]=
+static move_diff_type const move_diff_code[(square_h8 - square_a1 + 1) + (onerow + 1)]=
 {
   /* left/right   */        0,   1,   4,   9,  16,  25,  36,  49,
   /* dummies      */       UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX, UINT_MAX,
@@ -25,5 +27,13 @@ move_diff_type const move_diff_code[square_h8 - square_a1 + 1]=
   /* 6 right up   */       36,  37,  40,  45,  52,  61,  72,  85,
   /* dummies      */       UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX, UINT_MAX,
   /* 7 left  up   */            98,  85,  74,  65,  58,  53,  50,
-  /* 7 right up   */       49,  50,  53,  58,  65,  74,  85,  98
+  /* 7 right up   */       49,  50,  53,  58,  65,  74,  85,  98,
+  /* dummies      */       UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX, UINT_MAX,
+  /* dummies      */       UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX, UINT_MAX,
+  /* dummies      */       UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX,  UINT_MAX
 };
+
+move_diff_type squared_distance_between_squares(square sq1, square sq2)
+{
+  return move_diff_code[abs(sq1 - sq2)];
+}

--- a/position/move_diff_code.h
+++ b/position/move_diff_code.h
@@ -8,10 +8,6 @@
 
 typedef unsigned int move_diff_type;
 
-/* This are the codes for the length-difference */
-/* between two squares */
-/* ATTENTION: use abs(square from - square to) for indexing this table. */
-/*        all move_down_codes are mapped this way to move_up_codes !    */
-extern move_diff_type const move_diff_code[square_h8 - square_a1 + 1];
+move_diff_type squared_distance_between_squares(square sq1, square sq2);
 
 #endif

--- a/position/move_diff_code.h
+++ b/position/move_diff_code.h
@@ -8,6 +8,8 @@
 
 typedef unsigned int move_diff_type;
 
+/* This are the codes for the length-difference */
+/* between two squares */
 move_diff_type squared_distance_between_squares(square sq1, square sq2);
 
 #endif


### PR DESCRIPTION
This is my proposed fix to Issue #418.  Analogously to Issues #413, #414, and #419, the "problem" seems to be that the move generation logic sometimes tries to move pieces off the board.  As with PR #426, the simplest solution is to expand the array with appropriate slack space, a technique used elsewhere for the same purpose.  In each of the cases here we (apparently) need only ensure that there's enough slack to enable stepping one space outside the board, and for `move_diff_code` this only requires adding one additional row.

As long as I was making the above change, I also took the liberty of abstracting the interface.  No more remembering that we have to pass `abs(from - to)`; instead we'll just call a simple function that will do whatever is necessary.