### PR TITLE
Feature/enable flto

### DIFF
--- a/toolchains/C++BuilderX/make.incl
+++ b/toolchains/C++BuilderX/make.incl
@@ -98,7 +98,7 @@ LDFLAGS=-q
 EXEFILE=-e
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/MSVC12/make.incl
+++ b/toolchains/MSVC12/make.incl
@@ -101,7 +101,7 @@ LIBRARIES=WINMM.LIB
 # implement option maxtime)
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/MSVC6/make.incl
+++ b/toolchains/MSVC6/make.incl
@@ -100,7 +100,7 @@ LIBRARIES=WINMM.LIB
 # implement option maxtime)
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/MSVC8/make.incl
+++ b/toolchains/MSVC8/make.incl
@@ -102,7 +102,7 @@ LIBRARIES=WINMM.LIB
 # implement option maxtime)
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/Sun-cc/make.incl
+++ b/toolchains/Sun-cc/make.incl
@@ -84,7 +84,7 @@ LDOPTIM=-fast
 EXEFILE=-o 
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/cross-i386-mingw32msvc/make.incl
+++ b/toolchains/cross-i386-mingw32msvc/make.incl
@@ -41,7 +41,7 @@ STRIPTARGET=i386-mingw32msvc-strip
 ARCHIVE_INDEXER = i386-mingw32msvc-ranlib
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/cross-i586-mingw32msvc/make.incl
+++ b/toolchains/cross-i586-mingw32msvc/make.incl
@@ -50,7 +50,7 @@ TARGETLIBS=-lwinmm
 # implement option maxtime)
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/cross-x86_64-pc-linux/make.incl
+++ b/toolchains/cross-x86_64-pc-linux/make.incl
@@ -48,7 +48,7 @@ TARGETLIBS=-lwinmm
 # implement option maxtime)
 
 
-# Platform spedific file names and suffixes
+# Platform-specific file names and suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/cygwin-gcc/make.incl
+++ b/toolchains/cygwin-gcc/make.incl
@@ -18,7 +18,7 @@ include toolchains/gcc/make.incl
 
 # Now override where necessary
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for executables

--- a/toolchains/gcc/make.incl
+++ b/toolchains/gcc/make.incl
@@ -137,6 +137,7 @@ ARCH=                   # use platform default
 CCOPTIM=-O3
 # -fprofile-use
 # -fprofile-generate
+# -flto
 
 # Option for producing dependency information in makefile format
 DEPEND=-MM -MP
@@ -170,7 +171,7 @@ LDOPTIM=-O3
 EXEFILE=-o 
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/gcc/make.incl
+++ b/toolchains/gcc/make.incl
@@ -164,6 +164,7 @@ OTHER+=-std=c99
 LDOPTIM=-O3
 # -fprofile-use
 # -fprofile-generate
+# -flto
 
 # Option for naming objectfile
 # NOTE: the trailing blank on the following line is relevant (at least

--- a/toolchains/icc/make.incl
+++ b/toolchains/icc/make.incl
@@ -96,6 +96,7 @@ DEFINEMACRO=-D
 
 # Select target linker optimization level
 LDOPTIM=-O3
+# -ipo
 
 # Option for naming objectfile
 # NOTE: the trailing blank on the following line is relevant (at least

--- a/toolchains/icc/make.incl
+++ b/toolchains/icc/make.incl
@@ -74,6 +74,7 @@ DBG=-debug none
 
 # Select target compiler optimization level
 CCOPTIM=-O3
+# -ipo
 
 # Option for producing dependency information in makefile format
 DEPEND=-MM -MP
@@ -102,7 +103,7 @@ LDOPTIM=-O3
 EXEFILE=-o 
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/icx/make.incl
+++ b/toolchains/icx/make.incl
@@ -65,6 +65,7 @@ DBG=-debug none
 
 # Select target compiler optimization level
 CCOPTIM=-O3
+# -ipo
 
 # Option for producing dependency information in makefile format
 DEPEND=-MM -MP
@@ -93,7 +94,7 @@ LDOPTIM=-O3
 EXEFILE=-o 
 
 
-# Platform spedific file name suffixes
+# Platform-specific file name suffixes
 # ====================================
 
 # suffix for objects

--- a/toolchains/icx/make.incl
+++ b/toolchains/icx/make.incl
@@ -87,6 +87,7 @@ DEFINEMACRO=-D
 
 # Select target linker optimization level
 LDOPTIM=-O3
+# -ipo
 
 # Option for naming objectfile
 # NOTE: the trailing blank on the following line is relevant (at least


### PR DESCRIPTION
This branch simply _suggests_ compile & link parameters for enabling [interprocedural optimization](https://en.wikipedia.org/wiki/Interprocedural_optimization).  In my (admittedly limited) testing with [GCC](https://en.wikipedia.org/wiki/GNU_Compiler_Collection) this reduced runtime by about 13.8%, which is not bad for adding a single flag.