### PR TITLE
Feature/fix issue425

### DIFF
--- a/optimisations/intelligent/guard_flights.c
+++ b/optimisations/intelligent/guard_flights.c
@@ -21,17 +21,17 @@ static guard_dir_struct GuardDirArray[5][maxsquare+4];
 
 guard_dir_struct GuardDir(piece_walk_type p, square s)
 {
-  static guard_dir_struct const DummyGuardDir = {0};
-  assert(((p >= Pawn) &&
-          (p < (Pawn + ((sizeof GuardDirArray)/(sizeof GuardDirArray[0]))))) ||
-         (p == Dummy));
   if (p == Dummy)
   {
     guard_dir_struct const DummyGuardDir = {0};
     return DummyGuardDir;
   }
   else
+  {
+    assert((p >= Pawn) &&
+           (p < (Pawn + ((sizeof GuardDirArray)/(sizeof GuardDirArray[0])))));
     return GuardDirArray[p - Pawn][s];
+  }
 }
 
 static void init_guard_dirs_leaper(piece_walk_type guarder,

--- a/optimisations/intelligent/guard_flights.c
+++ b/optimisations/intelligent/guard_flights.c
@@ -21,11 +21,17 @@ static guard_dir_struct GuardDirArray[5][maxsquare+4];
 
 guard_dir_struct GuardDir(piece_walk_type p, square s)
 {
-  static guard_dir_struct const DummyGuardDir;
+  static guard_dir_struct const DummyGuardDir = {0};
   assert(((p >= Pawn) &&
           (p < (Pawn + ((sizeof GuardDirArray)/(sizeof GuardDirArray[0]))))) ||
          (p == Dummy));
-  return ((p == Dummy) ? DummyGuardDir : GuardDirArray[p - Pawn][s]);
+  if (p == Dummy)
+  {
+    guard_dir_struct const DummyGuardDir = {0};
+    return DummyGuardDir;
+  }
+  else
+    return GuardDirArray[p - Pawn][s];
 }
 
 static void init_guard_dirs_leaper(piece_walk_type guarder,

--- a/optimisations/intelligent/guard_flights.c
+++ b/optimisations/intelligent/guard_flights.c
@@ -18,10 +18,10 @@
 unsigned int index_of_guarding_piece;
 
 static guard_dir_struct GuardDirArray[5][maxsquare+4];
-static guard_dir_struct const DummyGuardDir;
 
 guard_dir_struct GuardDir(piece_walk_type p, square s)
 {
+  static guard_dir_struct const DummyGuardDir;
   assert(((p >= Pawn) &&
           (p < (Pawn + ((sizeof GuardDirArray)/(sizeof GuardDirArray[0]))))) ||
          (p == Dummy));

--- a/optimisations/intelligent/guard_flights.c
+++ b/optimisations/intelligent/guard_flights.c
@@ -21,7 +21,9 @@ static guard_dir_struct GuardDirArray[5][maxsquare+4];
 static guard_dir_struct const DummyGuardDir;
 
 guard_dir_struct const * GuardDir(piece_walk_type p, square s) {
-  assert(((p >= Pawn) && (p < (Pawn + 5))) || (p == Dummy));
+  assert(((p >= Pawn) &&
+          (p < (Pawn + ((sizeof GuardDirArray)/(sizeof GuardDirArray[0]))))) ||
+         (p == Dummy));
   return ((p == Dummy) ? &DummyGuardDir : &GuardDirArray[p - Pawn][s]);
 }
 
@@ -31,7 +33,8 @@ static void init_guard_dirs_leaper(piece_walk_type guarder,
                                    numvec value)
 {
   vec_index_type i;
-  assert((guarder >= Pawn) && (guarder < (Pawn + 5)));
+  assert((guarder >= Pawn) &&
+         (guarder < (Pawn + ((sizeof GuardDirArray)/(sizeof GuardDirArray[0])))));
   for (i = start; i <= end; ++i)
     GuardDirArray[guarder-Pawn][target+vec[i]].dir = value;
 }
@@ -49,7 +52,8 @@ static void init_guard_dirs_rider(piece_walk_type guarder,
   else
   {
     square s;
-    assert((guarder >= Pawn) && (guarder < (Pawn + 5)));
+    assert((guarder >= Pawn) &&
+           (guarder < (Pawn + ((sizeof GuardDirArray)/(sizeof GuardDirArray[0])))));
     for (s = start; is_square_empty(s); s += dir)
     {
       GuardDirArray[guarder-Pawn][s].dir = -dir;

--- a/optimisations/intelligent/guard_flights.c
+++ b/optimisations/intelligent/guard_flights.c
@@ -21,6 +21,8 @@ static guard_dir_struct GuardDirArray[5][maxsquare+4];
 
 guard_dir_struct GuardDir(piece_walk_type p, square s)
 {
+  assert((s >= 0) &&
+         (s < ((sizeof GuardDirArray[0])/(sizeof GuardDirArray[0][0]))));
   if (p == Dummy)
   {
     guard_dir_struct const DummyGuardDir = {0};

--- a/optimisations/intelligent/guard_flights.c
+++ b/optimisations/intelligent/guard_flights.c
@@ -208,6 +208,7 @@ void init_guard_dirs(square black_king_pos)
   init_guard_dirs_bishop(black_king_pos);
   init_guard_dirs_knight(black_king_pos);
   init_guard_dirs_pawn(black_king_pos);
+  /* Dummies can't guard anything, so we don't have to do anything for them. */
 }
 
 /* Does the white king guard a flight

--- a/optimisations/intelligent/guard_flights.c
+++ b/optimisations/intelligent/guard_flights.c
@@ -20,11 +20,12 @@ unsigned int index_of_guarding_piece;
 static guard_dir_struct GuardDirArray[5][maxsquare+4];
 static guard_dir_struct const DummyGuardDir;
 
-guard_dir_struct const * GuardDir(piece_walk_type p, square s) {
+guard_dir_struct GuardDir(piece_walk_type p, square s)
+{
   assert(((p >= Pawn) &&
           (p < (Pawn + ((sizeof GuardDirArray)/(sizeof GuardDirArray[0]))))) ||
          (p == Dummy));
-  return ((p == Dummy) ? &DummyGuardDir : &GuardDirArray[p - Pawn][s]);
+  return ((p == Dummy) ? DummyGuardDir : GuardDirArray[p - Pawn][s]);
 }
 
 static void init_guard_dirs_leaper(piece_walk_type guarder,
@@ -353,13 +354,13 @@ static void place_rider(slice_index si,
   TraceFunctionParamListEnd();
 
   {
-    int const dir = GuardDir(rider_type,guard_from)->dir;
+    guard_dir_struct const guard_dir = GuardDir(rider_type,guard_from);
 
-    TraceValue("%d",dir);
+    TraceValue("%d",guard_dir.dir);
     TraceValue("%d",guard_dir_check_uninterceptable);
     TraceEOL();
 
-    switch (dir)
+    switch (guard_dir.dir)
     {
       case guard_dir_check_uninterceptable:
       case 0:
@@ -367,7 +368,7 @@ static void place_rider(slice_index si,
 
       case guard_dir_guard_uninterceptable:
       {
-        square const guarded = GuardDir(rider_type,guard_from)->target;
+        square const guarded = guard_dir.target;
         TraceSquare(guarded);
         TraceValue("%u",TSTFLAG(being_solved.spec[guarded],Black));
         TraceWalk(get_walk_of_piece_on_square(guarded));
@@ -391,11 +392,11 @@ static void place_rider(slice_index si,
 
       default:
       {
-        square const guarded = GuardDir(rider_type,guard_from)->target;
+        square const guarded = guard_dir.target;
         TraceSquare(guarded);
         TraceValue("%u",TSTFLAG(being_solved.spec[guarded],Black));
         TraceEOL();
-        if (!TSTFLAG(being_solved.spec[guarded],Black) && is_line_empty(guard_from,guarded,dir))
+        if (!TSTFLAG(being_solved.spec[guarded],Black) && is_line_empty(guard_from,guarded,guard_dir.dir))
         {
           occupy_square(guard_from,rider_type,white[index_of_guarding_piece].flags);
           remember_to_keep_guard_line_open(guard_from,guarded,+1);
@@ -443,7 +444,7 @@ static void place_knight(slice_index si, square guard_from)
   TraceSquare(guard_from);
   TraceFunctionParamListEnd();
 
-  if (GuardDir(Knight,guard_from)->dir==guard_dir_guard_uninterceptable)
+  if (GuardDir(Knight,guard_from).dir==guard_dir_guard_uninterceptable)
   {
     occupy_square(guard_from,Knight,white[index_of_guarding_piece].flags);
     intelligent_continue_guarding_flights(si);
@@ -466,7 +467,7 @@ static void unpromoted_pawn(slice_index si, square guard_from)
   TraceFunctionParamListEnd();
 
   if (!TSTFLAGMASK(sq_spec(guard_from),BIT(WhBaseSq)|BIT(WhPromSq))
-      && GuardDir(Pawn,guard_from)->dir==guard_dir_guard_uninterceptable
+      && GuardDir(Pawn,guard_from).dir==guard_dir_guard_uninterceptable
       && intelligent_reserve_white_pawn_moves_from_to_no_promotion(starts_from,
                                                                    guard_from))
   {

--- a/optimisations/intelligent/guard_flights.h
+++ b/optimisations/intelligent/guard_flights.h
@@ -31,8 +31,8 @@ typedef struct
 /* index of guarding piece currently being placed */
 extern unsigned int index_of_guarding_piece;
 
-/* lookup doing something like GuardDir[Queen-Pawn][some_square] */
-extern guard_dir_struct GuardDir[5][maxsquare+4];
+/* lookup a guard direction GuardDir(Queen, some_square) */
+guard_dir_struct const * GuardDir(piece_walk_type p, square s);
 
 /* Initialise GuardDir
  * @param black_king_pos position of black king

--- a/optimisations/intelligent/guard_flights.h
+++ b/optimisations/intelligent/guard_flights.h
@@ -32,7 +32,7 @@ typedef struct
 extern unsigned int index_of_guarding_piece;
 
 /* lookup doing something like GuardDir(Queen, some_square) */
-guard_dir_struct const * GuardDir(piece_walk_type p, square s);
+guard_dir_struct GuardDir(piece_walk_type p, square s);
 
 /* Initialise GuardDir
  * @param black_king_pos position of black king

--- a/optimisations/intelligent/guard_flights.h
+++ b/optimisations/intelligent/guard_flights.h
@@ -31,7 +31,7 @@ typedef struct
 /* index of guarding piece currently being placed */
 extern unsigned int index_of_guarding_piece;
 
-/* lookup a guard direction GuardDir(Queen, some_square) */
+/* lookup doing something like GuardDir(Queen, some_square) */
 guard_dir_struct const * GuardDir(piece_walk_type p, square s);
 
 /* Initialise GuardDir

--- a/optimisations/intelligent/intercept_check_from_guard.c
+++ b/optimisations/intelligent/intercept_check_from_guard.c
@@ -31,7 +31,7 @@ static void place_officer(slice_index si,
   if (/* avoid duplicate: if intercepter has already been used as guarding
        * piece, it shouldn't guard now again */
       !(index_of_intercepting_piece<index_of_guarding_piece
-        && GuardDir[officer_type-Pawn][to_be_intercepted].dir!=0))
+        && GuardDir(officer_type,to_be_intercepted)->dir!=0))
   {
     occupy_square(to_be_intercepted,officer_type,intercepter_flags);
     intelligent_continue_guarding_flights(si);
@@ -135,7 +135,7 @@ static void unpromoted_pawn(slice_index si,
 {
   square const intercepter_diagram_square = white[index_of_intercepting_piece].diagram_square;
   Flags const intercepter_flags = white[index_of_intercepting_piece].flags;
-  numvec const guard_dir = GuardDir[Pawn-Pawn][to_be_intercepted].dir;
+  numvec const guard_dir = GuardDir(Pawn,to_be_intercepted)->dir;
 
   TraceFunctionEntry(__func__);
   TraceSquare(to_be_intercepted);

--- a/optimisations/intelligent/intercept_check_from_guard.c
+++ b/optimisations/intelligent/intercept_check_from_guard.c
@@ -31,7 +31,7 @@ static void place_officer(slice_index si,
   if (/* avoid duplicate: if intercepter has already been used as guarding
        * piece, it shouldn't guard now again */
       !(index_of_intercepting_piece<index_of_guarding_piece
-        && GuardDir(officer_type,to_be_intercepted)->dir!=0))
+        && GuardDir(officer_type,to_be_intercepted).dir!=0))
   {
     occupy_square(to_be_intercepted,officer_type,intercepter_flags);
     intelligent_continue_guarding_flights(si);
@@ -135,7 +135,7 @@ static void unpromoted_pawn(slice_index si,
 {
   square const intercepter_diagram_square = white[index_of_intercepting_piece].diagram_square;
   Flags const intercepter_flags = white[index_of_intercepting_piece].flags;
-  numvec const guard_dir = GuardDir(Pawn,to_be_intercepted)->dir;
+  numvec const guard_dir = GuardDir(Pawn,to_be_intercepted).dir;
 
   TraceFunctionEntry(__func__);
   TraceSquare(to_be_intercepted);

--- a/optimisations/intelligent/mate/generate_checking_moves.c
+++ b/optimisations/intelligent/mate/generate_checking_moves.c
@@ -284,7 +284,7 @@ static void by_unpromoted_pawn(slice_index si,
   TraceFunctionParamListEnd();
 
   if (!TSTFLAGMASK(sq_spec(check_from),prom_square)
-      && GuardDir[Pawn-Pawn][check_from].dir==guard_dir_check_uninterceptable
+      && GuardDir(Pawn,check_from)->dir==guard_dir_check_uninterceptable
       && intelligent_reserve_white_pawn_moves_from_to_checking(checker_from,check_from))
   {
     occupy_square(check_from,Pawn,checker_flags);

--- a/optimisations/intelligent/mate/generate_checking_moves.c
+++ b/optimisations/intelligent/mate/generate_checking_moves.c
@@ -284,7 +284,7 @@ static void by_unpromoted_pawn(slice_index si,
   TraceFunctionParamListEnd();
 
   if (!TSTFLAGMASK(sq_spec(check_from),prom_square)
-      && GuardDir(Pawn,check_from)->dir==guard_dir_check_uninterceptable
+      && GuardDir(Pawn,check_from).dir==guard_dir_check_uninterceptable
       && intelligent_reserve_white_pawn_moves_from_to_checking(checker_from,check_from))
   {
     occupy_square(check_from,Pawn,checker_flags);
@@ -359,13 +359,12 @@ static void by_knight(slice_index si,
 
 void intelligent_mate_generate_checking_moves(slice_index si)
 {
-  unsigned int index;
-
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
   if (intelligent_reserve_masses(White,1,piece_gives_check))
   {
+    unsigned int index;
     for (index = 1; index<MaxPiece[White]; ++index)
     {
       square const *bnp;

--- a/optimisations/intelligent/mate/generate_doublechecking_moves.c
+++ b/optimisations/intelligent/mate/generate_doublechecking_moves.c
@@ -285,7 +285,7 @@ static void front_check_by_pawn_promotion_without_capture(slice_index si,
     for (pp = pieces_pawns_promotee_sequence[pieces_pawns_promotee_chain_orthodox][Empty]; pp!=Empty; pp = pieces_pawns_promotee_sequence[pieces_pawns_promotee_chain_orthodox][pp])
       /* geometry doesn't allow for an interceptable check by a pawn that
        * doesn't capture */
-      if (GuardDir[pp-Pawn][check_from].dir==guard_dir_check_uninterceptable)
+      if (GuardDir(pp,check_from)->dir==guard_dir_check_uninterceptable)
       {
         occupy_square(check_from,pp,white[index_of_checker].flags);
         pipe_solve_delegate(si);

--- a/optimisations/intelligent/mate/generate_doublechecking_moves.c
+++ b/optimisations/intelligent/mate/generate_doublechecking_moves.c
@@ -285,7 +285,7 @@ static void front_check_by_pawn_promotion_without_capture(slice_index si,
     for (pp = pieces_pawns_promotee_sequence[pieces_pawns_promotee_chain_orthodox][Empty]; pp!=Empty; pp = pieces_pawns_promotee_sequence[pieces_pawns_promotee_chain_orthodox][pp])
       /* geometry doesn't allow for an interceptable check by a pawn that
        * doesn't capture */
-      if (GuardDir(pp,check_from)->dir==guard_dir_check_uninterceptable)
+      if (GuardDir(pp,check_from).dir==guard_dir_check_uninterceptable)
       {
         occupy_square(check_from,pp,white[index_of_checker].flags);
         pipe_solve_delegate(si);
@@ -321,13 +321,13 @@ static void front_check_by_pawn_promotion_with_capture(slice_index si,
     for (pp = pieces_pawns_promotee_sequence[pieces_pawns_promotee_chain_orthodox][Empty]; pp!=Empty; pp = pieces_pawns_promotee_sequence[pieces_pawns_promotee_chain_orthodox][pp])
       if (pp>=Queen && pp<=Bishop)
       {
-        int const dir = CheckDir(pp)[being_solved.king_square[Black]-check_from];
-        if (dir!=0)
+        int const check_dir = CheckDir(pp)[being_solved.king_square[Black]-check_from];
+        if (check_dir!=0)
           switch (pp)
           {
             case Queen:
             case Rook:
-              if (is_line_empty(check_from,being_solved.king_square[Black],dir))
+              if (is_line_empty(check_from,being_solved.king_square[Black],check_dir))
               {
                 occupy_square(check_from,pp,white[index_of_checker].flags);
                 remember_to_keep_checking_line_open(check_from,being_solved.king_square[Black],pp,+1);

--- a/optimisations/intelligent/place_white_piece.c
+++ b/optimisations/intelligent/place_white_piece.c
@@ -23,7 +23,7 @@ void intelligent_place_unpromoted_white_pawn(slice_index si,
   TraceFunctionParamListEnd();
 
   if (!TSTFLAGMASK(sq_spec(placed_on),BIT(WhBaseSq)|BIT(WhPromSq))
-      && GuardDir[Pawn-Pawn][placed_on].dir<guard_dir_guard_uninterceptable
+      && GuardDir(Pawn,placed_on)->dir<guard_dir_guard_uninterceptable
       && intelligent_reserve_white_pawn_moves_from_to_no_promotion(placed_comes_from,
                                                                    placed_on))
   {
@@ -44,8 +44,8 @@ void intelligent_place_promoted_white_rider(slice_index si,
 {
   square const placed_comes_from = white[placed_index].diagram_square;
   Flags const placed_flags = white[placed_index].flags;
-  int const dir = GuardDir[promotee_type-Pawn][placed_on].dir;
-  square const target = GuardDir[promotee_type-Pawn][placed_on].target;
+  int const dir = GuardDir(promotee_type,placed_on)->dir;
+  square const target = GuardDir(promotee_type,placed_on)->target;
 
   TraceFunctionEntry(__func__);
   TraceWalk(promotee_type);
@@ -88,7 +88,7 @@ void intelligent_place_promoted_white_knight(slice_index si,
   TraceSquare(placed_on);
   TraceFunctionParamListEnd();
 
-  if (GuardDir[Knight-Pawn][placed_on].dir<guard_dir_guard_uninterceptable
+  if (GuardDir(Knight,placed_on)->dir<guard_dir_guard_uninterceptable
       && intelligent_reserve_promoting_white_pawn_moves_from_to(placed_comes_from,
                                                                 Knight,
                                                                 placed_on))
@@ -162,8 +162,8 @@ static stack_elmt_type const *stack_top = 0;
 static void intercept_queen_diag(slice_index si)
 {
   square const placed_on = stack_top->placed_on;
-  int const dir_diag = GuardDir[Bishop-Pawn][placed_on].dir;
-  square const target_diag = GuardDir[Bishop-Pawn][placed_on].target;
+  int const dir_diag = GuardDir(Bishop,placed_on)->dir;
+  square const target_diag = GuardDir(Bishop,placed_on)->target;
 
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
@@ -185,8 +185,8 @@ void intelligent_place_white_queen(slice_index si,
   piece_walk_type const placed_type = white[placed_index].type;
   Flags const placed_flags = white[placed_index].flags;
   square const placed_comes_from = white[placed_index].diagram_square;
-  int const dir_ortho = GuardDir[Rook-Pawn][placed_on].dir;
-  int const dir_diag = GuardDir[Bishop-Pawn][placed_on].dir;
+  int const dir_ortho = GuardDir(Rook,placed_on)->dir;
+  int const dir_diag = GuardDir(Bishop,placed_on)->dir;
 
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",placed_index);
@@ -200,7 +200,7 @@ void intelligent_place_white_queen(slice_index si,
                                                    placed_type,
                                                    placed_on))
   {
-    square const target_ortho = GuardDir[Rook-Pawn][placed_on].target;
+    square const target_ortho = GuardDir(Rook,placed_on)->target;
 
     stack_elmt_type const new_top = { placed_index, placed_on, go_on, stack_top };
     stack_top = &new_top;
@@ -230,8 +230,8 @@ void intelligent_place_white_rider(slice_index si,
   piece_walk_type const placed_type = white[placed_index].type;
   Flags const placed_flags = white[placed_index].flags;
   square const placed_comes_from = white[placed_index].diagram_square;
-  int const dir = GuardDir[placed_type-Pawn][placed_on].dir;
-  square const target = GuardDir[placed_type-Pawn][placed_on].target;
+  int const dir = GuardDir(placed_type,placed_on)->dir;
+  square const target = GuardDir(placed_type,placed_on)->target;
 
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",placed_index);
@@ -299,7 +299,7 @@ void intelligent_place_white_knight(slice_index si,
   TraceSquare(placed_on);
   TraceFunctionParamListEnd();
 
-  switch (GuardDir[Knight-Pawn][placed_on].dir)
+  switch (GuardDir(Knight,placed_on)->dir)
   {
     case guard_dir_check_uninterceptable:
       break;

--- a/optimisations/orthodox_mating_moves/orthodox_mating_move_generator.c
+++ b/optimisations/orthodox_mating_moves/orthodox_mating_move_generator.c
@@ -470,14 +470,15 @@ static void generate_move_reaching_goal(void)
   square square_a = square_a1;
   Side const side_at_move = trait[nbply];
   square const OpponentsKing = side_at_move==White ? being_solved.king_square[Black] : being_solved.king_square[White];
-  int i;
 
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
   if (OpponentsKing!=initsquare)
+  {
     /* Don't try to "optimize" by hand. The double-loop is tested as
      * the fastest way to compute (due to compiler-optimizations!) */
+    int i;
     for (i = nr_rows_on_board; i>0; i--, square_a += onerow)
     {
       int j;
@@ -526,6 +527,7 @@ static void generate_move_reaching_goal(void)
             }
         }
       }
+    }
   }
 
   TraceFunctionExit(__func__);

--- a/pieces/attributes/total_invisible.c
+++ b/pieces/attributes/total_invisible.c
@@ -840,7 +840,7 @@ static void subsitute_goal_guard(slice_index si,
 }
 
 static void instrument_replay_branch(slice_index si,
-                                     stip_structure_traversal const *st)
+                                     stip_structure_traversal *st)
 {
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",si);

--- a/pieces/attributes/total_invisible.c
+++ b/pieces/attributes/total_invisible.c
@@ -439,9 +439,7 @@ static void adapt_pre_capture_effect(void)
         {
           if (is_square_empty(sq_addition))
           {
-            square const sq_addition = move_effect_journal[pre_capture].u.piece_addition.added.on;
             piece_walk_type const walk_added = move_effect_journal[pre_capture].u.piece_addition.added.walk;
-            Flags const flags_added = move_effect_journal[pre_capture].u.piece_addition.added.flags;
             PieceIdType const id_added = GetPieceId(flags_added);
 
             TraceText("addition of a castling partner - not yet revealed\n");
@@ -842,7 +840,7 @@ static void subsitute_goal_guard(slice_index si,
 }
 
 static void instrument_replay_branch(slice_index si,
-                                     stip_structure_traversal *st)
+                                     stip_structure_traversal const *st)
 {
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",si);


### PR DESCRIPTION
This is my proposed fix for Issue #425.  In that Issue the problem is that when Popeye is run on

    BeginProblem
    title Popeye 4.85 printed dummies as total invisibles in the solution
    author Andrew Buchanan
    pieces white kg1 bg7 pf2 duf8 black ka1 pc2d4
    Stipulation h#6
    Option Intelligent 2 movenum
    Condition PromOnly Q R S B DU
    EndProblem

line 288 of [`optimisations/intelligent/mate/generate_doublechecking_moves.c`](https://github.com/thomas-maeder/popeye/blob/develop/optimisations/intelligent/mate/generate_doublechecking_moves.c) attempts to examine `GuardDir[Dummy-Pawn]` which, of course, doesn't exist.

This fix abstracts the `GuardDir` interface, allowing us to easily provide a `guard_dir_struct` for any piece we may eventually desire, constructed in whatever way is most convenient.  (For now, I've only added `Dummy`, in the way that I feel is appropriate.)  This update also allows us to add some [`assert`](https://en.cppreference.com/w/cpp/error/assert)s so that we can catch similar errors going forward.

Though I believe these changes are worthwhile, and they _do_ eliminate the invalid accesses in the Issue, I do want to mention a few points.  That line of code looks for `GuardDir[Dummy-Pawn]`, but _no other parts of the code seem to do so_.  It finds `Dummy` in `pieces_pawns_promotee_sequence[pieces_pawns_promotee_chain_orthodox]`, which certainly seems odd (to me) as `Dummy` isn't an orthodox piece.  Thus, it's _conceivable_ that `Dummy` shouldn't be appearing there, that there's a bug elsewhere that's causing this to happen that should be fixed.  Someone who better understands this infrastructure should weigh in here.