### PR TITLE
Feature/shift en passant range

### DIFF
--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -1476,7 +1476,7 @@ byte *CommonEncode(byte *bp,
   {
     unsigned int i;
 
-    for (i = en_passant_top[nbply-1]+1; i<=en_passant_top[nbply]; ++i)
+    for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
       *bp++ = (byte)(en_passant_multistep_over[i] - square_a1);
   }
 

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -1476,7 +1476,7 @@ byte *CommonEncode(byte *bp,
   {
     unsigned int i;
 
-    for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
+    for (i = en_passant_end[nbply-1]; i<en_passant_end[nbply]; ++i)
       *bp++ = (byte)(en_passant_multistep_over[i] - square_a1);
   }
 

--- a/optimisations/intelligent/mate/finish.c
+++ b/optimisations/intelligent/mate/finish.c
@@ -59,7 +59,7 @@ static boolean exists_redundant_white_piece(slice_index si)
   boolean result = false;
   square const *bnp;
   castling_rights_type const save_castling_flag = being_solved.castling_rights;
-  unsigned int const save_ep = en_passant_top[nbply-1];
+  unsigned int const save_ep = en_passant_end[nbply-1];
 
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
@@ -73,7 +73,7 @@ static boolean exists_redundant_white_piece(slice_index si)
   CLRCASTLINGFLAGMASK(Black,k_cancastle);
 
   /* same for en passant */
-  en_passant_top[nbply-1] = en_passant_top[nbply];
+  en_passant_end[nbply-1] = en_passant_end[nbply];
 
   /* check for redundant white pieces */
   for (bnp = boardnum; !result && *bnp!=initsquare; bnp++)
@@ -98,7 +98,7 @@ static boolean exists_redundant_white_piece(slice_index si)
     }
   }
 
-  en_passant_top[nbply-1] = save_ep;
+  en_passant_end[nbply-1] = save_ep;
 
   being_solved.castling_rights = save_castling_flag;
 

--- a/optimisations/intelligent/stalemate/immobilise_black.c
+++ b/optimisations/intelligent/stalemate/immobilise_black.c
@@ -127,7 +127,7 @@ boolean intelligent_stalemate_immobilise_black(slice_index si)
   boolean result = false;
   immobilisation_state_type immobilisation_state = null_state;
   castling_rights_type const save_castling_flag = being_solved.castling_rights;
-  unsigned int const save_en_passant_top = en_passant_top[nbply];
+  unsigned int const save_en_passant_end = en_passant_end[nbply];
 
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
@@ -142,13 +142,13 @@ boolean intelligent_stalemate_immobilise_black(slice_index si)
   current_state = &immobilisation_state;
 
   /* we temporarily disable en passant captures for similar reasons */
-  en_passant_top[nbply] = en_passant_top[nbply-1];
+  en_passant_end[nbply] = en_passant_end[nbply-1];
 
   conditional_pipe_solve_delegate(si);
 
   next_trouble_maker();
 
-  en_passant_top[nbply] = save_en_passant_top;
+  en_passant_end[nbply] = save_en_passant_end;
   current_state = 0;
   being_solved.castling_rights = save_castling_flag;
 

--- a/optimisations/orthodox_square_observation.c
+++ b/optimisations/orthodox_square_observation.c
@@ -78,7 +78,7 @@ static boolean en_passant_test_check_ortho(Side side_checking,
     ply const ply_parent = parent_ply[nbply];
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_end[ply_parent-1]; i<en_passant_end[ply_parent]; ++i)
     {
       square const sq_crossed = en_passant_multistep_over[i];
       if (sq_crossed!=initsquare

--- a/optimisations/orthodox_square_observation.c
+++ b/optimisations/orthodox_square_observation.c
@@ -78,7 +78,7 @@ static boolean en_passant_test_check_ortho(Side side_checking,
     ply const ply_parent = parent_ply[nbply];
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]+1; i<=en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
     {
       square const sq_crossed = en_passant_multistep_over[i];
       if (sq_crossed!=initsquare

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -207,15 +207,15 @@ void move_effect_journal_redo_remember_ep(move_effect_journal_entry_type const *
 }
 
 /* Was a pawn multistep move played in a certain ply?
- * @param ply the ply
- * @return true iff a multi step move was played in ply ply
+ * @param ply_to_check the ply
+ * @return true iff a multi step move was played in ply ply_to_check
  */
-boolean en_passant_was_multistep_played(ply ply)
+boolean en_passant_was_multistep_played(ply ply_to_check)
 {
-  boolean const result = en_passant_top[nbply]>en_passant_top[nbply-1];
+  boolean const result = en_passant_top[ply_to_check]>en_passant_top[ply_to_check-1];
 
   TraceFunctionEntry(__func__);
-  TraceFunctionParam("%u",ply);
+  TraceFunctionParam("%u",ply_to_check);
   TraceFunctionParamListEnd();
 
   TraceFunctionExit(__func__);

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -15,7 +15,7 @@
 
 #include "debugging/assert.h"
 
-square en_passant_multistep_over[maxply+1];
+square en_passant_multistep_over[maxply];
 
 unsigned int en_passant_top[maxply+1];
 
@@ -139,8 +139,7 @@ void en_passant_remember_multistep_over(square s)
 
   assert(s!=initsquare);
 
-  ++en_passant_top[nbply];
-  en_passant_multistep_over[en_passant_top[nbply]] = s;
+  en_passant_multistep_over[en_passant_top[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -172,8 +171,7 @@ void move_effect_journal_do_remember_ep(square s)
 
   entry->u.ep_capture_potential.capture_square = s;
 
-  ++en_passant_top[nbply];
-  en_passant_multistep_over[en_passant_top[nbply]] = s;
+  en_passant_multistep_over[en_passant_top[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -202,8 +200,7 @@ void move_effect_journal_redo_remember_ep(move_effect_journal_entry_type const *
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  ++en_passant_top[nbply];
-  en_passant_multistep_over[en_passant_top[nbply]] = s;
+  en_passant_multistep_over[en_passant_top[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -290,7 +287,7 @@ boolean en_passant_test_check(numvec dir_capture,
   {
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]+1; i<=en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
     {
       square const sq_crossed = en_passant_multistep_over[i];
       if (sq_crossed!=initsquare
@@ -334,7 +331,7 @@ boolean en_passant_is_capture_possible_to(Side side, square s)
   {
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]+1; i<=en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
       if (en_passant_multistep_over[i]==s)
       {
         result = true;

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -15,6 +15,10 @@
 
 #include "debugging/assert.h"
 
+enum {
+  ENSURE_EP_MULTISTEP_OVER_SIZE_DOESNT_OVERFLOW = 1/(maxply <= ((-1U)/MAX_EP_MULTISTEP_OVER_PER_PLY))
+};
+
 square en_passant_multistep_over[maxply * MAX_EP_MULTISTEP_OVER_PER_PLY];
 
 unsigned int en_passant_top[maxply + 1];

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -15,7 +15,7 @@
 
 #include "debugging/assert.h"
 
-square en_passant_multistep_over[maxply * MAX_MULTISTEP_OVER_PER_PLY];
+square en_passant_multistep_over[maxply * MAX_EP_MULTISTEP_OVER_PER_PLY];
 
 unsigned int en_passant_top[maxply + 1];
 

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -139,6 +139,7 @@ void en_passant_remember_multistep_over(square s)
 
   assert(s!=initsquare);
 
+  assert((en_passant_top[nbply]-en_passant_top[nbply-1])<MAX_EP_MULTISTEP_OVER_PER_PLY);
   en_passant_multistep_over[en_passant_top[nbply]++] = s;
 
   TraceFunctionExit(__func__);
@@ -171,6 +172,7 @@ void move_effect_journal_do_remember_ep(square s)
 
   entry->u.ep_capture_potential.capture_square = s;
 
+  assert((en_passant_top[nbply]-en_passant_top[nbply-1])<MAX_EP_MULTISTEP_OVER_PER_PLY);
   en_passant_multistep_over[en_passant_top[nbply]++] = s;
 
   TraceFunctionExit(__func__);
@@ -200,6 +202,7 @@ void move_effect_journal_redo_remember_ep(move_effect_journal_entry_type const *
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
+  assert((en_passant_top[nbply]-en_passant_top[nbply-1])<MAX_EP_MULTISTEP_OVER_PER_PLY);
   en_passant_multistep_over[en_passant_top[nbply]++] = s;
 
   TraceFunctionExit(__func__);

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -15,9 +15,9 @@
 
 #include "debugging/assert.h"
 
-square en_passant_multistep_over[maxply];
+square en_passant_multistep_over[maxply * MAX_NUM_MULTISTEP_OVER];
 
-unsigned int en_passant_top[maxply+1];
+unsigned int en_passant_top[maxply + 1];
 
 square en_passant_retro_squares[en_passant_retro_capacity];
 unsigned int en_passant_nr_retro_squares;

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -21,7 +21,7 @@ enum {
 
 square en_passant_multistep_over[maxply * MAX_EP_MULTISTEP_OVER_PER_PLY];
 
-unsigned int en_passant_top[maxply + 1];
+unsigned int en_passant_end[maxply + 1];
 
 square en_passant_retro_squares[en_passant_retro_capacity];
 unsigned int en_passant_nr_retro_squares;
@@ -143,8 +143,8 @@ void en_passant_remember_multistep_over(square s)
 
   assert(s!=initsquare);
 
-  assert((en_passant_top[nbply]-en_passant_top[nbply-1])<MAX_EP_MULTISTEP_OVER_PER_PLY);
-  en_passant_multistep_over[en_passant_top[nbply]++] = s;
+  assert((en_passant_end[nbply]-en_passant_end[nbply-1])<MAX_EP_MULTISTEP_OVER_PER_PLY);
+  en_passant_multistep_over[en_passant_end[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -157,7 +157,7 @@ void en_passant_forget_multistep(void)
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  en_passant_top[ply_retro_move] = en_passant_top[ply_diagram_setup];
+  en_passant_end[ply_retro_move] = en_passant_end[ply_diagram_setup];
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -176,8 +176,8 @@ void move_effect_journal_do_remember_ep(square s)
 
   entry->u.ep_capture_potential.capture_square = s;
 
-  assert((en_passant_top[nbply]-en_passant_top[nbply-1])<MAX_EP_MULTISTEP_OVER_PER_PLY);
-  en_passant_multistep_over[en_passant_top[nbply]++] = s;
+  assert((en_passant_end[nbply]-en_passant_end[nbply-1])<MAX_EP_MULTISTEP_OVER_PER_PLY);
+  en_passant_multistep_over[en_passant_end[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -191,7 +191,7 @@ void move_effect_journal_undo_remember_ep(move_effect_journal_entry_type const *
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  --en_passant_top[nbply];
+  --en_passant_end[nbply];
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -206,8 +206,8 @@ void move_effect_journal_redo_remember_ep(move_effect_journal_entry_type const *
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  assert((en_passant_top[nbply]-en_passant_top[nbply-1])<MAX_EP_MULTISTEP_OVER_PER_PLY);
-  en_passant_multistep_over[en_passant_top[nbply]++] = s;
+  assert((en_passant_end[nbply]-en_passant_end[nbply-1])<MAX_EP_MULTISTEP_OVER_PER_PLY);
+  en_passant_multistep_over[en_passant_end[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -219,7 +219,7 @@ void move_effect_journal_redo_remember_ep(move_effect_journal_entry_type const *
  */
 boolean en_passant_was_multistep_played(ply ply_to_check)
 {
-  boolean const result = en_passant_top[ply_to_check]>en_passant_top[ply_to_check-1];
+  boolean const result = en_passant_end[ply_to_check]>en_passant_end[ply_to_check-1];
 
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",ply_to_check);
@@ -294,7 +294,7 @@ boolean en_passant_test_check(numvec dir_capture,
   {
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_end[ply_parent-1]; i<en_passant_end[ply_parent]; ++i)
     {
       square const sq_crossed = en_passant_multistep_over[i];
       if (sq_crossed!=initsquare
@@ -338,7 +338,7 @@ boolean en_passant_is_capture_possible_to(Side side, square s)
   {
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_end[ply_parent-1]; i<en_passant_end[ply_parent]; ++i)
       if (en_passant_multistep_over[i]==s)
       {
         result = true;

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -15,7 +15,7 @@
 
 #include "debugging/assert.h"
 
-square en_passant_multistep_over[maxply * MAX_NUM_MULTISTEP_OVER];
+square en_passant_multistep_over[maxply * MAX_MULTISTEP_OVER_PER_PLY];
 
 unsigned int en_passant_top[maxply + 1];
 

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -22,8 +22,8 @@ unsigned int en_passant_top[maxply + 1];
 square en_passant_retro_squares[en_passant_retro_capacity];
 unsigned int en_passant_nr_retro_squares;
 
-/* Determine whether the retro information concernng en passant is consistent
- * @return true iff the informatoin is consistent
+/* Determine whether the retro information concerning en passant is consistent
+ * @return true iff the information is consistent
  */
 boolean en_passant_are_retro_squares_consistent(void)
 {
@@ -268,7 +268,7 @@ static boolean en_passant_test_check_one_square_crossed(square sq_crossed,
 /* Determine whether side trait[nbply] gives check by p. capture
  * @param dir_capture direction of ep capture
  * @param tester pawn-specific tester function
- * @param evaluate address of evaluater function
+ * @param evaluate address of evaluator function
  * @return true if side trait[nbply] gives check by ep. capture
  */
 boolean en_passant_test_check(numvec dir_capture,

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -11,10 +11,10 @@
  */
 
 enum {
-  MAX_NUM_MULTISTEP_OVER = (nr_rows_on_board - 2) /* A pawn that jumps from the first rank to the last rank would cross this many squares.
-                                                     TODO: Is this a safe maximum?  Can we get away with a smaller value? */
+  MAX_MULTISTEP_OVER_PER_PLY = (nr_rows_on_board - 2) /* A pawn that jumps from the first rank to the last rank would cross this many squares.
+                                                         TODO: Is this a safe maximum?  Can we get away with a smaller value? */
 };
-extern square en_passant_multistep_over[maxply * MAX_NUM_MULTISTEP_OVER];
+extern square en_passant_multistep_over[maxply * MAX_MULTISTEP_OVER_PER_PLY];
 
 extern unsigned int en_passant_top[maxply + 1];
 

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -9,9 +9,13 @@
 /* This module provides implements en passant captures
  */
 
-extern square en_passant_multistep_over[maxply];
+enum {
+  MAX_NUM_MULTISTEP_OVER = (nr_rows_on_board - 2) /* A pawn that jumps from the first rank to the last rank would cross this many squares.
+                                                     TODO: Is this a safe maximum?  Can we get away with a smaller value? */
+};
+extern square en_passant_multistep_over[maxply * MAX_NUM_MULTISTEP_OVER];
 
-extern unsigned int en_passant_top[maxply+1];
+extern unsigned int en_passant_top[maxply + 1];
 
 enum
 {

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -26,8 +26,8 @@ enum
 extern square en_passant_retro_squares[en_passant_retro_capacity];
 extern unsigned int en_passant_nr_retro_squares;
 
-/* Determine whether the retro information concernng en passant is consistent
- * @return true iff the informatoin is consistent
+/* Determine whether the retro information concerning en passant is consistent
+ * @return true iff the information is consistent
  */
 boolean en_passant_are_retro_squares_consistent(void);
 
@@ -100,7 +100,7 @@ square en_passant_find_capturee(void);
  * @param sq_departure departure square of ep capture
  * @param sq_crossed square crossed by multistep move
  * @param p type of pawn
- * @param evaluate address of evaluater function
+ * @param evaluate address of evaluator function
  * @return true iff side trait[nbply] gives check by ep. capture to sq_arrival
  */
 typedef boolean (*en_passant_check_tester_type)(square sq_departure,
@@ -110,7 +110,7 @@ typedef boolean (*en_passant_check_tester_type)(square sq_departure,
 /* Determine whether side trait[nbply] gives check by p. capture
  * @param dir_capture direction of ep capture
  * @param tester pawn-specific tester function
- * @param evaluate address of evaluater function
+ * @param evaluate address of evaluator function
  * @return true if side trait[nbply] gives check by ep. capture
  */
 boolean en_passant_test_check(numvec dir_capture,

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -72,10 +72,10 @@ void en_passant_forget_multistep(void);
 void move_effect_journal_do_remember_ep(square s);
 
 /* Was a pawn multistep move played in a certain ply?
- * @param ply the ply
- * @return true iff a multi step move was played in ply ply
+ * @param ply_to_check the ply
+ * @return true iff a multi step move was played in ply ply_to_check
  */
-boolean en_passant_was_multistep_played(ply ply);
+boolean en_passant_was_multistep_played(ply ply_to_check);
 
 /* Is an en passant capture possible to a specific square?
  * @param side for which side

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -16,7 +16,7 @@ enum {
 };
 extern square en_passant_multistep_over[maxply * (unsigned int)MAX_EP_MULTISTEP_OVER_PER_PLY];
 
-extern unsigned int en_passant_top[maxply + 1];
+extern unsigned int en_passant_end[maxply + 1];
 
 enum
 {

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -9,7 +9,7 @@
 /* This module provides implements en passant captures
  */
 
-extern square en_passant_multistep_over[maxply+1];
+extern square en_passant_multistep_over[maxply];
 
 extern unsigned int en_passant_top[maxply+1];
 

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -5,6 +5,7 @@
 #include "solving/move_effect_journal.h"
 #include "solving/observation.h"
 #include "solving/ply.h"
+#include "position/board.h"
 
 /* This module provides implements en passant captures
  */

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -11,10 +11,10 @@
  */
 
 enum {
-  MAX_MULTISTEP_OVER_PER_PLY = (nr_rows_on_board - 2) /* A pawn that jumps from the first rank to the last rank would cross this many squares.
-                                                         TODO: Is this a safe maximum?  Can we get away with a smaller value? */
+  MAX_EP_MULTISTEP_OVER_PER_PLY = (nr_rows_on_board - 2) /* A pawn that jumps from the first rank to the last rank would cross this many squares.
+                                                            TODO: Is this a safe maximum?  Can we get away with a smaller value? */
 };
-extern square en_passant_multistep_over[maxply * MAX_MULTISTEP_OVER_PER_PLY];
+extern square en_passant_multistep_over[maxply * MAX_EP_MULTISTEP_OVER_PER_PLY];
 
 extern unsigned int en_passant_top[maxply + 1];
 

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -14,7 +14,7 @@ enum {
   MAX_EP_MULTISTEP_OVER_PER_PLY = (nr_rows_on_board - 2) /* A pawn that jumps from the first rank to the last rank would cross this many squares.
                                                             TODO: Is this a safe maximum?  Can we get away with a smaller value? */
 };
-extern square en_passant_multistep_over[maxply * MAX_EP_MULTISTEP_OVER_PER_PLY];
+extern square en_passant_multistep_over[maxply * (unsigned int)MAX_EP_MULTISTEP_OVER_PER_PLY];
 
 extern unsigned int en_passant_top[maxply + 1];
 

--- a/position/effects/board_transformation.c
+++ b/position/effects/board_transformation.c
@@ -46,7 +46,7 @@ static void transformBoard(SquareTransformation transformation)
   for (i= 0; i<maxinum; i++)
     being_solved.isquare[i]= transformSquare(t_isquare[i], transformation);
 
-  for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
+  for (i = en_passant_end[nbply-1]; i<en_passant_end[nbply]; ++i)
     en_passant_multistep_over[i] = transformSquare(en_passant_multistep_over[i], transformation);
 }
 

--- a/position/effects/board_transformation.c
+++ b/position/effects/board_transformation.c
@@ -46,7 +46,7 @@ static void transformBoard(SquareTransformation transformation)
   for (i= 0; i<maxinum; i++)
     being_solved.isquare[i]= transformSquare(t_isquare[i], transformation);
 
-  for (i = en_passant_top[nbply-1]+1; i<=en_passant_top[nbply]; ++i)
+  for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
     en_passant_multistep_over[i] = transformSquare(en_passant_multistep_over[i], transformation);
 }
 

--- a/solving/ply.c
+++ b/solving/ply.c
@@ -58,7 +58,7 @@ void nextply(Side side)
   TraceValue("%u",move_effect_journal_base[nbply+1]);
   TraceEOL();
 
-  en_passant_top[nbply] = en_passant_top[nbply-1];
+  en_passant_end[nbply] = en_passant_end[nbply-1];
   promotion_horizon[nbply] = move_effect_journal_base[nbply]+move_effect_journal_index_offset_other_effects-1;
 
   post_move_iteration_init_ply();
@@ -104,7 +104,7 @@ void siblingply(Side side)
   TraceValue("%u",move_effect_journal_base[nbply+1]);
   TraceEOL();
 
-  en_passant_top[nbply] = en_passant_top[nbply-1];
+  en_passant_end[nbply] = en_passant_end[nbply-1];
   promotion_horizon[nbply] = move_effect_journal_base[nbply]+move_effect_journal_index_offset_other_effects-1;
 
   post_move_iteration_init_ply();
@@ -145,7 +145,7 @@ void copyply(void)
   TraceValue("%u",move_effect_journal_base[nbply+1]);
   TraceEOL();
 
-  en_passant_top[nbply] = en_passant_top[nbply-1];
+  en_passant_end[nbply] = en_passant_end[nbply-1];
   promotion_horizon[nbply] = move_effect_journal_base[nbply]+move_effect_journal_index_offset_other_effects-1;
 
   post_move_iteration_init_ply();


### PR DESCRIPTION
While investigating Issue #433 I discovered some quirks in the en passant logic that I figured were worth eliminating.

At first I had to understand what was going on.&nbsp; I concluded that possible en passant capture `square`s are stored in `en_passant_multistep_over` with the range corresponding to a given `ply` delineated by `en_passant_top[nbply-1]` and `en_passant_top[nbply]`, each `unsigned int`s.&nbsp; What I found odd was that it's the _lower_ end that's open, i.e., the range is (`en_passant_top[nbply-1]`, `en_passant_top[nbply]`].&nbsp; This is a bit unusual&mdash;for example, C++ tends to prefer open _upper_ ends&mdash;and it has some unfortunate impacts on our usage:

1. It forces `en_passant_multistep_over` to contain a dummy 0<sup>th</sup> element that is never accessed.
2. When iterating forward (as we are wont to do):
    - We have to start by adding 1 to `en_passant_top[nbply-1]`.
    - Generically, we have to ensure that `en_passant_top[nbply] < UINT_MAX`, lest the loop be infinite.

I figured it was worth fixing all of these, so I shifted the range to [`en_passant_top[nbply-1]`, `en_passant_top[nbply]`).&nbsp; I later renamed `en_passant_top` to `en_passant_end` to align with C++'s naming as it felt odd to have `en_passant_top` contain a value that _isn't_ part of the range.

With the range shifted I could remove the extra element from `en_passant_multistep_over`, but that just begged the question.&nbsp; How large _should_ that array be?&nbsp; It needs to be large enough to store as many en passant `square`s as we'd ever need across all `ply`.&nbsp; While an overall limit is maybe possible, I figured it'd be easier to determine a maximum number per `ply` and then multiply that by `maxply`.&nbsp; At first I thought that the per-`ply` bound could maybe be 1, but then I saw that there could be at least as many as 2 in Einstein chess.&nbsp; I therefore went with `nr_rows_on_board - 2`, figuring that that's a conservative value that can handle a pawn jumping from the first rank to the last rank.&nbsp; I wouldn't be surprised to learn that a smaller value is possible, nor would I be surprised to learn that a larger value is necessary.

I further noticed that
```c
boolean en_passant_was_multistep_played(ply)
```
ignored its argument and just checked if there was a multistep at `ply` `nbply`.&nbsp; This isn't currently causing problems because at this moment `en_passant_was_multistep_played` is _always_ called with `nbply` as the argument (and this would be true even if my "suggested" fix to Issue #433 is applied).&nbsp; Nonetheless, if this function is going to exist then it should really satisfy its contract, so I went ahead and fixed that.

Finally, as long as I was making the above changes I figured I might as well fix a bunch of typos.