### PR TITLE
Feature/shift ep range

### DIFF
--- a/conditions/series_capture.c
+++ b/conditions/series_capture.c
@@ -21,13 +21,13 @@
 
 #include "debugging/assert.h"
 
-static void dump_en_passant_tops(char const *context)
+static void dump_en_passant_ends(char const *context)
 {
 /*  ply p;
-  printf("en_passant_tops: %s: ",context);
+  printf("en_passant_ends: %s: ",context);
 
   for (p = ply_retro_move; p<=nbply; ++p)
-    printf("%u:%u-",p,en_passant_top[p]);
+    printf("%u:%u-",p,en_passant_end[p]);
   printf("\n");*/
 }
 
@@ -206,8 +206,8 @@ void series_capture_ply_rewinder_solve(slice_index si)
   assert(nbply>=save_nbply);
   while (nbply>save_nbply)
   {
-    en_passant_top[nbply-1] = en_passant_top[nbply];
-    dump_en_passant_tops(__func__);
+    en_passant_end[nbply-1] = en_passant_end[nbply];
+    dump_en_passant_ends(__func__);
     finply();
   }
 
@@ -242,8 +242,8 @@ void series_capture_journal_fixer_solve(slice_index si)
   {
     move_effect_journal_base[nbply] = move_effect_journal_base[nbply+1];
     --nbply;
-    en_passant_top[nbply] = en_passant_top[nbply+1];
-    dump_en_passant_tops(__func__);
+    en_passant_end[nbply] = en_passant_end[nbply+1];
+    dump_en_passant_ends(__func__);
     series_capture_journal_fixer_solve(si);
     ++nbply;
   }
@@ -377,7 +377,7 @@ void series_capture_fork_solve(slice_index si)
     if (post_move_am_i_iterating())
     {
       ++nbply;
-      en_passant_top[nbply] = en_passant_top[nbply-1];
+      en_passant_end[nbply] = en_passant_end[nbply-1];
       play_secondary_movement(si);
 
       if (post_move_iteration_is_locked())

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -1336,8 +1336,8 @@ static byte *CommonEncode(byte *bp,
     unsigned int i;
 
     assert((en_passant_top[nbply]-en_passant_top[nbply-1])<=MAX_EN_PASSANT_TOP_DIFFERENCE);
-    for (i = en_passant_top[nbply-1]+1; i<=en_passant_top[nbply]; ++i)
-      *bp++ = (byte)(en_passant_multistep_over[i] - square_a1);
+    for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
+      *bp++ = (byte)(en_passant_multistep_over[i+1] - square_a1);
   }
 
   *bp++ = (byte)being_solved.castling_rights;     /* Castling_Flag */

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -1335,8 +1335,8 @@ static byte *CommonEncode(byte *bp,
   {
     unsigned int i;
 
-    assert((en_passant_top[nbply]-en_passant_top[nbply-1])<=MAX_EN_PASSANT_TOP_DIFFERENCE);
-    for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
+    assert((en_passant_end[nbply]-en_passant_end[nbply-1])<=MAX_EN_PASSANT_END_DIFFERENCE);
+    for (i = en_passant_end[nbply-1]; i<en_passant_end[nbply]; ++i)
       *bp++ = (byte)(en_passant_multistep_over[i] - square_a1);
   }
 

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -1335,7 +1335,7 @@ static byte *CommonEncode(byte *bp,
   {
     unsigned int i;
 
-    assert((en_passant_end[nbply]-en_passant_end[nbply-1])<=MAX_EN_PASSANT_END_DIFFERENCE);
+    assert((en_passant_end[nbply]-en_passant_end[nbply-1])<=MAX_NUM_EP_POSSIBILITIES);
     for (i = en_passant_end[nbply-1]; i<en_passant_end[nbply]; ++i)
       *bp++ = (byte)(en_passant_multistep_over[i] - square_a1);
   }

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -1337,7 +1337,7 @@ static byte *CommonEncode(byte *bp,
 
     assert((en_passant_top[nbply]-en_passant_top[nbply-1])<=MAX_EN_PASSANT_TOP_DIFFERENCE);
     for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
-      *bp++ = (byte)(en_passant_multistep_over[i+1] - square_a1);
+      *bp++ = (byte)(en_passant_multistep_over[i] - square_a1);
   }
 
   *bp++ = (byte)being_solved.castling_rights;     /* Castling_Flag */

--- a/optimisations/hash.h
+++ b/optimisations/hash.h
@@ -83,7 +83,7 @@ typedef unsigned char byte;
                      + 1 + 1 + 3 + 1
                      + bytes_per_spec
                      + 1 + 2
-                     + en_passant_top[nbply] - en_passant_top[nbply-1]
+                     + en_passant_end[nbply] - en_passant_end[nbply-1]
                      + 1
                      + sizeof BGL_values[White] + sizeof BGL_values[Black]
                      + 2
@@ -105,9 +105,9 @@ typedef unsigned char byte;
    - nr_ghosts <= underworld_capacity
    - bytes_per_spec <= 4
    - being_solved.number_of_imitators <= maxinum
-   en_passant_top[nbply] - en_passant_top[nbply-1] requires a bit more thought.  It should be an upper
+   en_passant_end[nbply] - en_passant_end[nbply-1] requires a bit more thought.  It should be an upper
    bound on the number of en passant squares stored per ply.  For now we'll assume that
-   - en_passant_top[nbply] - en_passant_top[nbply-1] <= nr_rows_on_board - 2
+   - en_passant_end[nbply] - en_passant_end[nbply-1] <= nr_rows_on_board - 2
    as (nr_rows_on_board - 2) is the number of squares that a pawn jumping from the first rank to the
    last rank would skip over.
    With all of the above, we can determine the maximum bytes that an encoding should take up.  We'll
@@ -118,13 +118,13 @@ enum {
   MAX_NR_GHOSTS = underworld_capacity,
   MAX_BYTES_PER_SPEC = 4,
   MAX_NUMBER_OF_IMITATORS = maxinum,
-  MAX_EN_PASSANT_TOP_DIFFERENCE = nr_rows_on_board - 2, /* TODO: Is this a safe maximum?  Can we get away with a smaller value? */
+  MAX_EN_PASSANT_END_DIFFERENCE = nr_rows_on_board - 2, /* TODO: Is this a safe maximum?  Can we get away with a smaller value? */
   COMMONENCODE_MAX =   2 + 2 + 1 + 1 + 1
                      + MAX_NUMBER_OF_IMITATORS
                      + 1 + 1 + 3 + 1
                      + MAX_BYTES_PER_SPEC
                      + 1 + 2
-                     + MAX_EN_PASSANT_TOP_DIFFERENCE
+                     + MAX_EN_PASSANT_END_DIFFERENCE
                      + 1
                      + sizeof BGL_values[White] + sizeof BGL_values[Black]
                      + 2

--- a/optimisations/hash.h
+++ b/optimisations/hash.h
@@ -118,13 +118,13 @@ enum {
   MAX_NR_GHOSTS = underworld_capacity,
   MAX_BYTES_PER_SPEC = 4,
   MAX_NUMBER_OF_IMITATORS = maxinum,
-  MAX_EN_PASSANT_END_DIFFERENCE = nr_rows_on_board - 2, /* TODO: Is this a safe maximum?  Can we get away with a smaller value? */
+  MAX_NUM_EP_POSSIBILITIES = nr_rows_on_board - 2, /* TODO: Is this a safe maximum?  Can we get away with a smaller value? */
   COMMONENCODE_MAX =   2 + 2 + 1 + 1 + 1
                      + MAX_NUMBER_OF_IMITATORS
                      + 1 + 1 + 3 + 1
                      + MAX_BYTES_PER_SPEC
                      + 1 + 2
-                     + MAX_EN_PASSANT_END_DIFFERENCE
+                     + MAX_NUM_EP_POSSIBILITIES
                      + 1
                      + sizeof BGL_values[White] + sizeof BGL_values[Black]
                      + 2

--- a/optimisations/intelligent/mate/finish.c
+++ b/optimisations/intelligent/mate/finish.c
@@ -59,7 +59,7 @@ static boolean exists_redundant_white_piece(slice_index si)
   boolean result = false;
   square const *bnp;
   castling_rights_type const save_castling_flag = being_solved.castling_rights;
-  unsigned int const save_ep = en_passant_top[nbply-1];
+  unsigned int const save_ep = en_passant_end[nbply-1];
 
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
@@ -73,7 +73,7 @@ static boolean exists_redundant_white_piece(slice_index si)
   CLRCASTLINGFLAGMASK(Black,k_cancastle);
 
   /* same for en passant */
-  en_passant_top[nbply-1] = en_passant_top[nbply];
+  en_passant_end[nbply-1] = en_passant_end[nbply];
 
   /* check for redundant white pieces */
   for (bnp = boardnum; !result && *bnp!=initsquare; bnp++)
@@ -98,7 +98,7 @@ static boolean exists_redundant_white_piece(slice_index si)
     }
   }
 
-  en_passant_top[nbply-1] = save_ep;
+  en_passant_end[nbply-1] = save_ep;
 
   being_solved.castling_rights = save_castling_flag;
 

--- a/optimisations/intelligent/stalemate/immobilise_black.c
+++ b/optimisations/intelligent/stalemate/immobilise_black.c
@@ -127,7 +127,7 @@ boolean intelligent_stalemate_immobilise_black(slice_index si)
   boolean result = false;
   immobilisation_state_type immobilisation_state = null_state;
   castling_rights_type const save_castling_flag = being_solved.castling_rights;
-  unsigned int const save_en_passant_top = en_passant_top[nbply];
+  unsigned int const save_en_passant_end = en_passant_end[nbply];
 
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
@@ -142,13 +142,13 @@ boolean intelligent_stalemate_immobilise_black(slice_index si)
   current_state = &immobilisation_state;
 
   /* we temporarily disable en passant captures for similar reasons */
-  en_passant_top[nbply] = en_passant_top[nbply-1];
+  en_passant_end[nbply] = en_passant_end[nbply-1];
 
   conditional_pipe_solve_delegate(si);
 
   next_trouble_maker();
 
-  en_passant_top[nbply] = save_en_passant_top;
+  en_passant_end[nbply] = save_en_passant_end;
   current_state = 0;
   being_solved.castling_rights = save_castling_flag;
 

--- a/optimisations/orthodox_square_observation.c
+++ b/optimisations/orthodox_square_observation.c
@@ -80,7 +80,7 @@ static boolean en_passant_test_check_ortho(Side side_checking,
 
     for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
     {
-      square const sq_crossed = en_passant_multistep_over[i+1];
+      square const sq_crossed = en_passant_multistep_over[i];
       if (sq_crossed!=initsquare
           && pawn_test_check_ortho(side_checking,sq_crossed-dir_capture))
       {

--- a/optimisations/orthodox_square_observation.c
+++ b/optimisations/orthodox_square_observation.c
@@ -78,9 +78,9 @@ static boolean en_passant_test_check_ortho(Side side_checking,
     ply const ply_parent = parent_ply[nbply];
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]+1; i<=en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
     {
-      square const sq_crossed = en_passant_multistep_over[i];
+      square const sq_crossed = en_passant_multistep_over[i+1];
       if (sq_crossed!=initsquare
           && pawn_test_check_ortho(side_checking,sq_crossed-dir_capture))
       {

--- a/optimisations/orthodox_square_observation.c
+++ b/optimisations/orthodox_square_observation.c
@@ -78,7 +78,7 @@ static boolean en_passant_test_check_ortho(Side side_checking,
     ply const ply_parent = parent_ply[nbply];
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_end[ply_parent-1]; i<en_passant_end[ply_parent]; ++i)
     {
       square const sq_crossed = en_passant_multistep_over[i];
       if (sq_crossed!=initsquare

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -293,9 +293,9 @@ boolean en_passant_test_check(numvec dir_capture,
   {
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]+1; i<=en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
     {
-      square const sq_crossed = en_passant_multistep_over[i];
+      square const sq_crossed = en_passant_multistep_over[i+1];
       if (sq_crossed!=initsquare
           && en_passant_test_check_one_square_crossed(sq_crossed,
                                                       dir_capture,
@@ -340,8 +340,8 @@ boolean en_passant_is_capture_possible_to(Side side, square s)
     TraceValue("%u",en_passant_top[ply_parent-1]);
     TraceValue("%u",en_passant_top[ply_parent]);
     TraceEOL();
-    for (i = en_passant_top[ply_parent-1]+1; i<=en_passant_top[ply_parent]; ++i)
-      if (en_passant_multistep_over[i]==s)
+    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
+      if (en_passant_multistep_over[i+1]==s)
       {
         result = true;
         break;

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -17,7 +17,7 @@
 
 square en_passant_multistep_over[maxply];
 
-unsigned int en_passant_top[maxply+1];
+unsigned int en_passant_end[maxply+1];
 
 square en_passant_retro_squares[en_passant_retro_capacity];
 unsigned int en_passant_nr_retro_squares;
@@ -139,7 +139,7 @@ void en_passant_remember_multistep_over(square s)
 
   assert(s!=initsquare);
 
-  en_passant_multistep_over[en_passant_top[nbply]++] = s;
+  en_passant_multistep_over[en_passant_end[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -152,7 +152,7 @@ void en_passant_forget_multistep(void)
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  en_passant_top[ply_retro_move] = en_passant_top[ply_diagram_setup];
+  en_passant_end[ply_retro_move] = en_passant_end[ply_diagram_setup];
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -171,9 +171,9 @@ void move_effect_journal_do_remember_ep(square s)
 
   entry->u.ep_capture_potential.capture_square = s;
 
-  en_passant_multistep_over[en_passant_top[nbply]++] = s;
+  en_passant_multistep_over[en_passant_end[nbply]++] = s;
   TraceValue("%u",nbply);
-  TraceValue("%u",en_passant_top[nbply]);
+  TraceValue("%u",en_passant_end[nbply]);
   TraceEOL();
 
   TraceFunctionExit(__func__);
@@ -188,7 +188,7 @@ void move_effect_journal_undo_remember_ep(move_effect_journal_entry_type const *
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  --en_passant_top[nbply];
+  --en_passant_end[nbply];
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -203,7 +203,7 @@ void move_effect_journal_redo_remember_ep(move_effect_journal_entry_type const *
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  en_passant_multistep_over[en_passant_top[nbply]++] = s;
+  en_passant_multistep_over[en_passant_end[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -215,7 +215,7 @@ void move_effect_journal_redo_remember_ep(move_effect_journal_entry_type const *
  */
 boolean en_passant_was_multistep_played(ply ply)
 {
-  boolean const result = en_passant_top[ply]>en_passant_top[ply-1];
+  boolean const result = en_passant_end[ply]>en_passant_end[ply-1];
 
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",ply);
@@ -290,7 +290,7 @@ boolean en_passant_test_check(numvec dir_capture,
   {
     unsigned int i;
 
-    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_end[ply_parent-1]; i<en_passant_end[ply_parent]; ++i)
     {
       square const sq_crossed = en_passant_multistep_over[i];
       if (sq_crossed!=initsquare
@@ -334,10 +334,10 @@ boolean en_passant_is_capture_possible_to(Side side, square s)
   {
     unsigned int i;
 
-    TraceValue("%u",en_passant_top[ply_parent-1]);
-    TraceValue("%u",en_passant_top[ply_parent]);
+    TraceValue("%u",en_passant_end[ply_parent-1]);
+    TraceValue("%u",en_passant_end[ply_parent]);
     TraceEOL();
-    for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
+    for (i = en_passant_end[ply_parent-1]; i<en_passant_end[ply_parent]; ++i)
       if (en_passant_multistep_over[i]==s)
       {
         result = true;

--- a/pieces/walks/pawns/en_passant.c
+++ b/pieces/walks/pawns/en_passant.c
@@ -15,7 +15,7 @@
 
 #include "debugging/assert.h"
 
-square en_passant_multistep_over[maxply+1];
+square en_passant_multistep_over[maxply];
 
 unsigned int en_passant_top[maxply+1];
 
@@ -139,8 +139,7 @@ void en_passant_remember_multistep_over(square s)
 
   assert(s!=initsquare);
 
-  ++en_passant_top[nbply];
-  en_passant_multistep_over[en_passant_top[nbply]] = s;
+  en_passant_multistep_over[en_passant_top[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -172,11 +171,10 @@ void move_effect_journal_do_remember_ep(square s)
 
   entry->u.ep_capture_potential.capture_square = s;
 
-  ++en_passant_top[nbply];
+  en_passant_multistep_over[en_passant_top[nbply]++] = s;
   TraceValue("%u",nbply);
   TraceValue("%u",en_passant_top[nbply]);
   TraceEOL();
-  en_passant_multistep_over[en_passant_top[nbply]] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -205,8 +203,7 @@ void move_effect_journal_redo_remember_ep(move_effect_journal_entry_type const *
   TraceFunctionEntry(__func__);
   TraceFunctionParamListEnd();
 
-  ++en_passant_top[nbply];
-  en_passant_multistep_over[en_passant_top[nbply]] = s;
+  en_passant_multistep_over[en_passant_top[nbply]++] = s;
 
   TraceFunctionExit(__func__);
   TraceFunctionResultEnd();
@@ -295,7 +292,7 @@ boolean en_passant_test_check(numvec dir_capture,
 
     for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
     {
-      square const sq_crossed = en_passant_multistep_over[i+1];
+      square const sq_crossed = en_passant_multistep_over[i];
       if (sq_crossed!=initsquare
           && en_passant_test_check_one_square_crossed(sq_crossed,
                                                       dir_capture,
@@ -341,7 +338,7 @@ boolean en_passant_is_capture_possible_to(Side side, square s)
     TraceValue("%u",en_passant_top[ply_parent]);
     TraceEOL();
     for (i = en_passant_top[ply_parent-1]; i<en_passant_top[ply_parent]; ++i)
-      if (en_passant_multistep_over[i+1]==s)
+      if (en_passant_multistep_over[i]==s)
       {
         result = true;
         break;

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -9,7 +9,7 @@
 /* This module provides implements en passant captures
  */
 
-extern square en_passant_multistep_over[maxply+1];
+extern square en_passant_multistep_over[maxply];
 
 extern unsigned int en_passant_top[maxply+1];
 

--- a/pieces/walks/pawns/en_passant.h
+++ b/pieces/walks/pawns/en_passant.h
@@ -11,7 +11,7 @@
 
 extern square en_passant_multistep_over[maxply];
 
-extern unsigned int en_passant_top[maxply+1];
+extern unsigned int en_passant_end[maxply+1];
 
 enum
 {

--- a/position/effects/board_transformation.c
+++ b/position/effects/board_transformation.c
@@ -46,7 +46,7 @@ static void transformBoard(SquareTransformation transformation)
   for (i= 0; i<maxinum; i++)
     being_solved.isquare[i]= transformSquare(t_isquare[i], transformation);
 
-  for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
+  for (i = en_passant_end[nbply-1]; i<en_passant_end[nbply]; ++i)
     en_passant_multistep_over[i] = transformSquare(en_passant_multistep_over[i], transformation);
 }
 

--- a/position/effects/board_transformation.c
+++ b/position/effects/board_transformation.c
@@ -47,7 +47,7 @@ static void transformBoard(SquareTransformation transformation)
     being_solved.isquare[i]= transformSquare(t_isquare[i], transformation);
 
   for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
-    en_passant_multistep_over[i+1] = transformSquare(en_passant_multistep_over[i+1], transformation);
+    en_passant_multistep_over[i] = transformSquare(en_passant_multistep_over[i], transformation);
 }
 
 /* Add transforming the board to the current move of the current ply

--- a/position/effects/board_transformation.c
+++ b/position/effects/board_transformation.c
@@ -46,8 +46,8 @@ static void transformBoard(SquareTransformation transformation)
   for (i= 0; i<maxinum; i++)
     being_solved.isquare[i]= transformSquare(t_isquare[i], transformation);
 
-  for (i = en_passant_top[nbply-1]+1; i<=en_passant_top[nbply]; ++i)
-    en_passant_multistep_over[i] = transformSquare(en_passant_multistep_over[i], transformation);
+  for (i = en_passant_top[nbply-1]; i<en_passant_top[nbply]; ++i)
+    en_passant_multistep_over[i+1] = transformSquare(en_passant_multistep_over[i+1], transformation);
 }
 
 /* Add transforming the board to the current move of the current ply

--- a/solving/ply.c
+++ b/solving/ply.c
@@ -65,7 +65,7 @@ void nextply(Side side)
   TraceValue("%u",move_effect_journal_base[nbply+1]);
   TraceEOL();
 
-  en_passant_top[nbply] = en_passant_top[nbply-1];
+  en_passant_end[nbply] = en_passant_end[nbply-1];
   promotion_horizon[nbply] = move_effect_journal_base[nbply]+move_effect_journal_index_offset_other_effects-1;
 
   post_move_iteration_init_ply();
@@ -111,7 +111,7 @@ void siblingply(Side side)
   TraceValue("%u",move_effect_journal_base[nbply+1]);
   TraceEOL();
 
-  en_passant_top[nbply] = en_passant_top[nbply-1];
+  en_passant_end[nbply] = en_passant_end[nbply-1];
   promotion_horizon[nbply] = move_effect_journal_base[nbply]+move_effect_journal_index_offset_other_effects-1;
 
   post_move_iteration_init_ply();
@@ -152,7 +152,7 @@ void copyply(void)
   TraceValue("%u",move_effect_journal_base[nbply+1]);
   TraceEOL();
 
-  en_passant_top[nbply] = en_passant_top[nbply-1];
+  en_passant_end[nbply] = en_passant_end[nbply-1];
   promotion_horizon[nbply] = move_effect_journal_base[nbply]+move_effect_journal_index_offset_other_effects-1;
 
   post_move_iteration_init_ply();


### PR DESCRIPTION
This makes a few small tweaks to the en passant machinery that, IMO, make things cleaner.  Notes:

- Instead of using `en_passant_top` to indicate the maximum allowed value of the range, we use `en_passant_end` to indicate the _open_ upper bound, i.e., the smallest value that is _not_ part of the range.
- The above change allows the loops to be more idiomatic, with an initial setting (and no `+1`) and the test using the strict `<`.&nbsp; (This ensures that arithmetic overflow can't make those loops infinite.)
- We further shift the assignments into `en_passant_multistep_over` to one element lower.&nbsp; (This works because we were _never_ assigning to element 0.)
- The impact of the above is that we can save an element in `en_passant_multistep_over`.

To be honest, I'm still not sure that the dimension of `en_passant_multistep_over` is correct, that it's large enough to hold everything that it might need to.&nbsp; I tried to estimate the maximum size of each range in [`optimisations/hash.h`](https://github.com/thomas-maeder/popeye/blob/develop/optimisations/hash.h) as `MAX_EN_PASSANT_TOP_DIFFERENCE` (now `MAX_NUM_EP_POSSIBILITIES`), which I set to `nr_rows_on_board - 2`.&nbsp; Naïvely I'd expect `en_passant_multistep_over` to require dimension up to `MAX_EN_PASSANT_TOP_DIFFERENCE * maxply` = `(nr_rows_on_board - 2) * maxply`, but neither the current code nor the code in this PR sets it to that.&nbsp; I'd appreciate any explanations and/or guidance here.