### PR TITLE
Feature/add static assert

### DIFF
--- a/DHT/dhtbcmem.c
+++ b/DHT/dhtbcmem.c
@@ -23,9 +23,7 @@
 #include "dhtbcmem.h"
 #include "dht.h"
 
-enum {
-  ENSURE_SIZE_OF_ELEMENT_IS_ONE = 1/(1 == sizeof ((BCMemValue const *)NULL)->Data[0])
-};
+STATIC_ASSERT(1 == sizeof ((BCMemValue const *)NULL)->Data[0], "sizeof BCMemValue element must be 1.");
 
 static dhtHashValue ConvertBCMemValue(dhtKey m)
 {

--- a/DHT/dhtcmem.c
+++ b/DHT/dhtcmem.c
@@ -24,7 +24,7 @@
 typedef unsigned long uLong;
 typedef unsigned char uChar;
 
-STATIC_ASSERT(1 == sizeof NilCompactMemVal->Data[0], "CompactMemVal data element must have size 1.");
+STATIC_ASSERT(1 == sizeof NilCompactMemVal->Data[0], "sizeof CompactMemVal element must be 1.");
 
 static dhtHashValue ConvertCompactMemoryValue(dhtKey m)
 {

--- a/DHT/dhtcmem.c
+++ b/DHT/dhtcmem.c
@@ -24,9 +24,7 @@
 typedef unsigned long uLong;
 typedef unsigned char uChar;
 
-enum {
-  ENSURE_SIZE_OF_ELEMENT_IS_ONE = 1/(1 == sizeof NilCompactMemVal->Data[0])
-};
+STATIC_ASSERT(1 == sizeof NilCompactMemVal->Data[0], "CompactMemVal data element must have size 1.");
 
 static dhtHashValue ConvertCompactMemoryValue(dhtKey m)
 {

--- a/DHT/dhtmem.c
+++ b/DHT/dhtmem.c
@@ -24,9 +24,7 @@
 typedef unsigned long uLong;
 typedef unsigned char uChar;
 
-enum {
-  ENSURE_SIZE_OF_ELEMENT_IS_ONE = 1/(1 == sizeof NilMemVal->Data[0])
-};
+STATIC_ASSERT(1 == sizeof NilMemVal->Data[0], "sizeof BCMemValue element must be 1.");
 
 static dhtHashValue HashMemoryValue(dhtKey k)
 {

--- a/DHT/fxf.c
+++ b/DHT/fxf.c
@@ -173,19 +173,19 @@ enum
 #endif
 };
 
-enum {
-  ENSURE_FXFMINSIZE_GT_0 = 1/(fxfMINSIZE > 0),
-  ENSURE_FXFMAXSIZE_GE_FXFMINSIZE = 1/(fxfMAXSIZE >= fxfMINSIZE),
+STATIC_ASSERT(fxfMINSIZE > 0, "fxfMINSIZE must be > 0.");
+STATIC_ASSERT(fxfMAXSIZE >= fxfMINSIZE, "fxfMAXSIZE must be >= fxfMINSIZE.");
 #if defined(SEGMENT)
-  ENSURE_SEGMENTS_ALIGNED = 1/!((ARENA_SEG_SIZE & (((ARENA_SEG_SIZE < MAX_ALIGNMENT) ? NOT_MULTIPLE_ALIGNMENT : MAX_ALIGNMENT) - 1U)) &&
-                                (ARENA_SEG_SIZE & (ARENA_SEG_SIZE - 1U))),
+STATIC_ASSERT(!((ARENA_SEG_SIZE & (((ARENA_SEG_SIZE < MAX_ALIGNMENT) ? NOT_MULTIPLE_ALIGNMENT :
+                                                                       MAX_ALIGNMENT)
+                                   - 1U)) &&
+                (ARENA_SEG_SIZE & (ARENA_SEG_SIZE - 1U))), "Segments must be aligned.");
 #endif
-  ENSURE_FXFMAXSIZE_ALIGNED = 1/((!CLEAR_BOTTOM_BIT(fxfMAXSIZE)) ||
+STATIC_ASSERT((!CLEAR_BOTTOM_BIT(fxfMAXSIZE)) ||
                                  ((fxfMAXSIZE < MAX_ALIGNMENT) && !(fxfMAXSIZE & (NOT_MULTIPLE_ALIGNMENT - 1U))) ||
-                                 !(fxfMAXSIZE & (MAX_ALIGNMENT - 1U))),
-  ENSURE_ALIGNMENT_ORDERED = 1/((NOT_MULTIPLE_ALIGNMENT > 0) && (NOT_MULTIPLE_ALIGNMENT <= MAX_ALIGNMENT)),
-  ENSURE_ALIGNMENTS_POWERS_OF_2 = 1/!(CLEAR_BOTTOM_BIT(NOT_MULTIPLE_ALIGNMENT) || CLEAR_BOTTOM_BIT(MAX_ALIGNMENT))
-};
+                                 !(fxfMAXSIZE & (MAX_ALIGNMENT - 1U)), "fxfMAXSIZE must be aligned.");
+STATIC_ASSERT((NOT_MULTIPLE_ALIGNMENT > 0) && (NOT_MULTIPLE_ALIGNMENT <= MAX_ALIGNMENT), "Alignments must be properly ordered.");
+STATIC_ASSERT(!(CLEAR_BOTTOM_BIT(NOT_MULTIPLE_ALIGNMENT) || CLEAR_BOTTOM_BIT(MAX_ALIGNMENT)), "Alignments must be powers of 2.");
 
 #define MIN_ALIGNMENT_UNDERESTIMATE (((NOT_MULTIPLE_ALIGNMENT>>1) < fxfMINSIZE) ? NOT_MULTIPLE_ALIGNMENT : \
                                                                                   (CLEAR_BOTTOM_BIT(fxfMINSIZE) ? (BOTTOM_BIT(fxfMINSIZE)<<2) : \

--- a/debugging/assert.c
+++ b/debugging/assert.c
@@ -1,8 +1,4 @@
-#if !defined(NDEBUG)
-
-#if defined(__GNUC__) || defined(__clang__)
-
-#if !defined(AUXILIARY)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(AUXILIARY)
 
 #include "debugging/assert.h"
 #include "options/movenumbers.h"
@@ -12,6 +8,10 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#if !defined(ASSERT_IMPL_DECLARED)
+void assert_impl(char const *assertion, char const *file, int line, char const *func);
+#endif
 
 void assert_impl(char const *assertion, char const *file, int line, char const *func)
 {
@@ -32,10 +32,8 @@ void assert_impl(char const *assertion, char const *file, int line, char const *
   exit(1);
 }
 
-#endif
-
-#endif
-
-#endif
+#else
 
 extern unsigned char ASSERT_C_NONEMPTY_TRANSLATION_UNIT;
+
+#endif

--- a/debugging/assert.c
+++ b/debugging/assert.c
@@ -1,3 +1,9 @@
+#if !defined(NDEBUG)
+
+#if defined(__GNUC__) || defined(__clang__)
+
+#if !defined(AUXILIARY)
+
 #include "debugging/assert.h"
 #include "options/movenumbers.h"
 #include "solving/move_generator.h"
@@ -6,8 +12,6 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#if defined(__GNUC__)
 
 void assert_impl(char const *assertion, char const *file, int line, char const *func)
 {
@@ -29,3 +33,9 @@ void assert_impl(char const *assertion, char const *file, int line, char const *
 }
 
 #endif
+
+#endif
+
+#endif
+
+extern unsigned char ASSERT_C_NONEMPTY_TRANSLATION_UNIT;

--- a/debugging/assert.h
+++ b/debugging/assert.h
@@ -39,7 +39,7 @@ void assert_impl(char const *assertion, char const *file, int line, char const *
      This implementation is based on the May 2016 version at
          https://www.pixelbeat.org/programming/gcc/static_assert.html
      and we settle for the simple, universal version which cannot be used multiple
-     times on the same line (or on the first line of switch block).
+     times on the same line (or on the first line of a switch block).
   */       
   #define STATIC_ASSERT_CAT_IMPL_IMPL(a, b) a##b
   #define STATIC_ASSERT_CAT_IMPL(a, b) STATIC_ASSERT_CAT_IMPL_IMPL(a, b)

--- a/debugging/assert.h
+++ b/debugging/assert.h
@@ -34,8 +34,9 @@ void assert_impl(char const *assertion, char const *file, int line, char const *
   /* Use
          STATIC_ASSERT(cond, msg)
      to test cond at compile-time (which must be possible).  If cond is false
-     then compilationn will fail.  This allows us to test our expected invariants.
-     A string literal indicating the test and/or failure is recommended for msg.
+     then compilation will fail.  This allows us to verify that our expected
+     invariants still hold.  A string literal indicating the test and/or failure
+     is recommended for msg, to aid in correcting any errors identified.
      This implementation is based on the May 2016 version at
          https://www.pixelbeat.org/programming/gcc/static_assert.html
      and we settle for the simple, universal version which cannot be used multiple

--- a/debugging/assert.h
+++ b/debugging/assert.h
@@ -32,7 +32,7 @@ void assert_impl(char const *assertion, char const *file, int line, char const *
 
 #if !defined(STATIC_ASSERT)
   /* Use
-         STATIC_ASSERT(cond, msg)
+         STATIC_ASSERT(cond, msg);
      to test cond at compile-time (which must be possible).  If cond is false
      then compilation will fail.  This allows us to verify that our expected
      invariants still hold.  A string literal indicating the test and/or failure

--- a/debugging/assert.h
+++ b/debugging/assert.h
@@ -48,6 +48,6 @@ void assert_impl(char const *assertion, char const *file, int line, char const *
   #define STATIC_ASSERT_CAT_IMPL_IMPL(a, b) a##b
   #define STATIC_ASSERT_CAT_IMPL(a, b) STATIC_ASSERT_CAT_IMPL_IMPL(a, b)
   #define STATIC_ASSERT(cond, msg) enum { \
-                                     STATIC_ASSERT_CAT_IMPL(static_assert_on_line_, __LINE__) = 1/(int)!!(cond) \
+                                     STATIC_ASSERT_CAT_IMPL(static_assert_failure_on_line_, __LINE__) = 1/(int)!!(cond) \
                                    }
 #endif

--- a/debugging/assert.h
+++ b/debugging/assert.h
@@ -41,6 +41,9 @@ void assert_impl(char const *assertion, char const *file, int line, char const *
          https://www.pixelbeat.org/programming/gcc/static_assert.html
      and we settle for the simple, universal version which cannot be used multiple
      times on the same line (or on the first line of a switch block).
+     This implementation declares a useless enum.  Placing these inside a block
+     will prevent those enums from leaking into the surrounding context.  Alas,
+     that doesn't work at global scope.
   */       
   #define STATIC_ASSERT_CAT_IMPL_IMPL(a, b) a##b
   #define STATIC_ASSERT_CAT_IMPL(a, b) STATIC_ASSERT_CAT_IMPL_IMPL(a, b)

--- a/debugging/assert.h
+++ b/debugging/assert.h
@@ -21,9 +21,29 @@
 
 #else
 
+#if !defined(ASSERT_IMPL_DECLARED)
 void assert_impl(char const *assertion, char const *file, int line, char const *func);
+#  define ASSERT_IMPL_DECLARED
+#endif
 
 #define assert(expr) ((expr) ? (void)0 : assert_impl(#expr,__FILE__,__LINE__,__func__))
 
 #endif
 
+#if !defined(STATIC_ASSERT)
+  /* Use
+         STATIC_ASSERT(cond, msg)
+     to test cond at compile-time (which must be possible).  If cond is false
+     then compilationn will fail.  This allows us to test our expected invariants.
+     A string literal indicating the test and/or failure is recommended for msg.
+     This implementation is based on the May 2016 version at
+         https://www.pixelbeat.org/programming/gcc/static_assert.html
+     and we settle for the simple, universal version which cannot be used multiple
+     times on the same line (or on the first line of switch block).
+  */       
+  #define STATIC_ASSERT_CAT_IMPL_IMPL(a, b) a##b
+  #define STATIC_ASSERT_CAT_IMPL(a, b) STATIC_ASSERT_CAT_IMPL_IMPL(a, b)
+  #define STATIC_ASSERT(cond, msg) enum { \
+                                     STATIC_ASSERT_CAT_IMPL(static_assert_on_line_, __LINE__) = 1/(int)!!(cond) \
+                                   }
+#endif

--- a/optimisations/hash.c
+++ b/optimisations/hash.c
@@ -2883,14 +2883,11 @@ void hash_opener_solve(slice_index si)
 void check_hash_assumptions(void)
 {
   {
-    enum
-    {
-      /* SmallEncode uses 1 byte for both row and file of a square */
-      ensure_nr_rows_on_board_lt_one_shifted_by_CHAR_BIT_over_two = 1/(nr_rows_on_board<(1<<(CHAR_BIT/2))),
-      ensure_nr_files_on_board_lt_one_shifted_by_CHAR_BIT_over_two = 1/(nr_files_on_board<(1<<(CHAR_BIT/2))),
+    /* SmallEncode uses 1 byte for both row and file of a square */
+    STATIC_ASSERT(nr_rows_on_board<(1<<(CHAR_BIT/2)), "nr_rows_on_board must fit in half a char.");
+    STATIC_ASSERT(nr_files_on_board<(1<<(CHAR_BIT/2)), "nr_files_on_board must fit in half a char.");
 
-      /* LargeEncode() uses 1 bit per square */
-      ensure_nr_files_on_board_le_CHAR_BIT = 1/(nr_files_on_board<=CHAR_BIT)
-    };
+    /* LargeEncode() uses 1 bit per square */
+    STATIC_ASSERT(nr_files_on_board<=CHAR_BIT, "char must have at least one bit for each file.");
   }
 }

--- a/optimisations/intelligent/intelligent.c
+++ b/optimisations/intelligent/intelligent.c
@@ -954,11 +954,8 @@ void intelligent_mode_support_detector_or(slice_index si,
     /* enumerators are ordered so that the weakest support has the
      * lowest enumerator etc. */
     {
-      enum
-      {
-        ensure_intelligent_not_supported_lt_intelligent_not_active_by_default = 1/(intelligent_not_supported<intelligent_not_active_by_default),
-        ensure_intelligent_not_active_by_default_lt_intelligent_active_by_default = 1/(intelligent_not_active_by_default<intelligent_active_by_default)
-      };
+      STATIC_ASSERT(intelligent_not_supported<intelligent_not_active_by_default, "intelligent_not_supported must be < intelligent_not_active by default.");
+      STATIC_ASSERT(intelligent_not_active_by_default<intelligent_active_by_default, "intelligent_not_active_by_defaultt must be < intelligent_active_by_default.");
     }
 
     stip_traverse_structure_binary_operand1(si,st);

--- a/optimisations/orthodox_check_directions.c
+++ b/optimisations/orthodox_check_directions.c
@@ -22,15 +22,12 @@ static void InitCheckDir(void)
   unsigned int j;
 
   {
-    enum
-    {
-      ensure_Queen_lt_Rook = 1/(Queen<Rook),
-      ensure_Rook_minus_Queen_lt_4 = 1/((Rook-Queen)<4),
-      ensure_Queen_lt_Bishop = 1/(Queen<Bishop),
-      ensure_Bishop_minus_Queen_lt_4 = 1/((Bishop-Queen)<4),
-      ensure_Queen_lt_Knight = 1/(Queen<Knight),
-      ensure_Knight_minus_Queen_lt_4 = 1/((Knight-Queen)<4)
-    };
+    STATIC_ASSERT(Queen<Rook, "Queen must be < Rook.");
+    STATIC_ASSERT((Rook-Queen)<4, "Rook - Queen must be < 4.");
+    STATIC_ASSERT(Queen<Bishop, "Queen must be < Bishop.");
+    STATIC_ASSERT((Bishop-Queen)<4, "Bishop - Queen must be < 4.");
+    STATIC_ASSERT(Queen<Knight, "Queen must be < Knight.");
+    STATIC_ASSERT((Knight-Queen)<4, "Knight - Queen must < 4.");
   }
 
   for (i = 0; i<=2*(square_h8-square_a1); i++)

--- a/position/board.c
+++ b/position/board.c
@@ -18,10 +18,7 @@ static board_label_type const BOARD_ROW_LABELS[] = {'1', '2', '3', '4', '5', '6'
 board_label_type getBoardFileLabel(unsigned int const index) /* index should be in [0, nr_files_on_board-1] */
 {
   {
-    enum
-    {
-      ensure_we_have_enough_board_file_labels = 1/(nr_files_on_board <= ((sizeof BOARD_FILE_LABELS)/(sizeof *BOARD_FILE_LABELS)))
-    };
+    STATIC_ASSERT(nr_files_on_board <= ((sizeof BOARD_FILE_LABELS)/(sizeof *BOARD_FILE_LABELS)), "We must have enough board file labels.");
   }
   assert(index < nr_files_on_board);
   return BOARD_FILE_LABELS[index];
@@ -30,10 +27,7 @@ board_label_type getBoardFileLabel(unsigned int const index) /* index should be 
 board_label_type getBoardRowLabel(unsigned int const index) /* index should be in [0, nr_rows_on_board-1] */
 {
   {
-    enum
-    {
-      ensure_we_have_enough_board_row_labels = 1/(nr_rows_on_board <= ((sizeof BOARD_ROW_LABELS)/(sizeof *BOARD_ROW_LABELS)))
-    };
+    STATIC_ASSERT(nr_rows_on_board <= ((sizeof BOARD_ROW_LABELS)/(sizeof *BOARD_ROW_LABELS)), "We must have enough board row labels.");
   }
   assert(index < nr_rows_on_board);
   return BOARD_ROW_LABELS[index];
@@ -42,10 +36,7 @@ board_label_type getBoardRowLabel(unsigned int const index) /* index should be i
 unsigned int getBoardFileIndex(board_label_type const label) /* returns nr_files_on_board if label is invalid */
 {
   {
-    enum
-    {
-      ensure_we_have_enough_board_file_labels = 1/(nr_files_on_board <= ((sizeof BOARD_FILE_LABELS)/(sizeof *BOARD_FILE_LABELS)))
-    };
+    STATIC_ASSERT(nr_files_on_board <= ((sizeof BOARD_FILE_LABELS)/(sizeof *BOARD_FILE_LABELS)), "We must have enough board file labels.");
   }
   unsigned int index;
   for (index = 0; ((index < nr_files_on_board) && (BOARD_FILE_LABELS[index] != label)); ++index)
@@ -56,10 +47,7 @@ unsigned int getBoardFileIndex(board_label_type const label) /* returns nr_files
 unsigned int getBoardRowIndex(board_label_type const label) /* returns nr_rows_on_board if label is invalid */
 {
   {
-    enum
-    {
-      ensure_we_have_enough_board_row_labels = 1/(nr_rows_on_board <= ((sizeof BOARD_ROW_LABELS)/(sizeof *BOARD_ROW_LABELS)))
-    };
+    STATIC_ASSERT(nr_rows_on_board <= ((sizeof BOARD_ROW_LABELS)/(sizeof *BOARD_ROW_LABELS)), "We must have enough board row labels.");
   }
   unsigned int index;
   for (index = 0; ((index < nr_rows_on_board) && (BOARD_ROW_LABELS[index] != label)); ++index)

--- a/position/pieceid.h
+++ b/position/pieceid.h
@@ -3,6 +3,7 @@
 
 #include "pieces/pieces.h"
 #include "position/board.h"
+#include "debugging/assert.h"
 
 enum
 {
@@ -21,10 +22,7 @@ typedef unsigned long       PieceIdType;
 #define GetPieceId(spec)    ((spec) >> PieceIdOffset)
 #define ClearPieceId(spec)  SetPieceId(spec,NullPieceId)
 
-enum
-{
-  ENSURE_PIECEIDWIDTH_IS_LARGE_ENOUGH=1/!((MaxPieceId>>(PieceIdWidth-1u))>>1)
-};
+STATIC_ASSERT(!((MaxPieceId>>(PieceIdWidth-1u))>>1), "PieceIdWidth must be large enough.");
 
 extern square PiecePositionsInDiagram[MaxPieceId+1];
 

--- a/solving/machinery/twin.c
+++ b/solving/machinery/twin.c
@@ -2193,10 +2193,7 @@ static twin_label_type const TWIN_LABELS[] = {'a', 'b', 'c', 'd', 'e', 'f', 'g',
 twin_label_type getTwinLabel(unsigned int const index) /* index should be in [0, numTwinLabels()-1] */
 {
   {
-    enum
-    {
-      ensure_we_have_enough_twin_labels = 1/(nr_twin_labels <= ((sizeof TWIN_LABELS)/(sizeof *TWIN_LABELS)))
-    };
+    STATIC_ASSERT(nr_twin_labels <= ((sizeof TWIN_LABELS)/(sizeof *TWIN_LABELS)), "We must have enough twin labels.");
   }
   TraceFunctionEntry(__func__);
   TraceFunctionParam("%u",index);


### PR DESCRIPTION
This update adds a `STATIC_ASSERT` macro that can be used to test compile-time conditions at compile time.&nbsp; If a condition fails then compilation will fail, and otherwise use of this macro should impose no runtime overhead.&nbsp; We should use these liberally to ensure that our assumptions remain valid as the codebase continues to change.