### PR TITLE
fix(spinach): correct French keywords in spinach.tcl

### DIFF
--- a/spinach.tcl
+++ b/spinach.tcl
@@ -108,9 +108,9 @@ namespace eval language {
 	}
 
 	namespace eval input {
-	    variable BeginProblem "DebugProblem"
+	    variable BeginProblem "DebutProbleme"
 	    variable NextProblem "Asuivre"
-	    variable EndProblem "FinProblem"
+	    variable EndProblem "FinProbleme"
 	    variable ZeroPosition "zeroposition"
 	    variable Twin "Jumeau"
 	    variable Continued "enplus"


### PR DESCRIPTION
- Fixes French input
- Eliminates spurious error in locale-less environments